### PR TITLE
CHANGELOG for secured interest + minor fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Changes
   Renamed the ndn::time::steady_clock wrapper (only needed for macOS) to
   ndn::scheduler::MonotonicSteadyClock.
 * Add support for chacha20-Poly1305 in NAC. https://github.com/operantnetworks/ndn-ind/pull/7
+* Add support for a group content key (GCK) and secured interest in NAC.
 * In Interest, changed the MustBeFresh default value to false.
 * Added Tlv0_3WireFormat.
 * In Face, also check for a Unix socket at /var/tmp/nfd.sock .

--- a/include/ndn-ind/encrypt/encryptor-v2.hpp
+++ b/include/ndn-ind/encrypt/encryptor-v2.hpp
@@ -349,9 +349,9 @@ public:
    * @param checkForNewGckInterval The interval.
    */
   void
-  setcheckForNewGckInterval(std::chrono::nanoseconds checkForNewGckInterval)
+  setCheckForNewGckInterval(std::chrono::nanoseconds checkForNewGckInterval)
   {
-    impl_->setcheckForNewGckInterval(checkForNewGckInterval);
+    impl_->setCheckForNewGckInterval(checkForNewGckInterval);
   }
 
   /**
@@ -492,7 +492,7 @@ private:
     regenerateCk();
 
     void
-    setcheckForNewGckInterval(std::chrono::nanoseconds checkForNewGckInterval)
+    setCheckForNewGckInterval(std::chrono::nanoseconds checkForNewGckInterval)
     {
       checkForNewGckInterval_ = checkForNewGckInterval;
     }
@@ -577,7 +577,7 @@ private:
 
     /**
      * Decrypt the gckData fetched by fetchGck(), then copy it to ckBits_ and
-     * copy gckName to ckName_ . Then process pending encrypts.
+     * copy gckName to ckName_ . Then process pending decrypts.
      * @param gckName The Name that fetchGck() used to fetch.
      * @param gckData The GCK Data packet fetched by fetchGck().
      * @param onError On failure, this calls onError(errorCode, message)

--- a/src/encrypt/decryptor-v2.cpp
+++ b/src/encrypt/decryptor-v2.cpp
@@ -58,7 +58,7 @@ DecryptorV2::decrypt
     encryptedContent->wireDecodeV2(interest.getApplicationParameters());
   } catch (const std::exception& ex) {
     onError(EncryptError::ErrorCode::DecryptionFailure,
-      std::string("Error decoding the Data content as EncryptedContent: ") + ex.what());
+      std::string("Error decoding the Interest ApplicationParameters as EncryptedContent: ") + ex.what());
     return;
   }
 

--- a/src/encrypt/decryptor-v2.cpp
+++ b/src/encrypt/decryptor-v2.cpp
@@ -461,13 +461,13 @@ DecryptorV2::Impl::fetchGck
       (const ptr_lib::shared_ptr<const Interest>& ckInterest,
        const ptr_lib::shared_ptr<Data>& ckData)
     {
+      contentKey_->pendingInterest = 0;
+
       // Validate the Data signature.
       parent_->validator_->validate
         (*ckData,
         [=](auto&) {
           try {
-            contentKey_->pendingInterest = 0;
-
             // Pass an empty kdkKeyName so that we decrypt with the credentialsKey_.
             parent_->decryptCkAndProcessPendingDecrypts
               (*contentKey_, *ckData, Name(), onError_);

--- a/src/encrypt/encryptor-v2.cpp
+++ b/src/encrypt/encryptor-v2.cpp
@@ -541,12 +541,13 @@ EncryptorV2::Impl::checkForNewGck(const EncryptError::OnError& onError)
            try {
              newGckName.wireDecode(gckLatestData->getContent());
            } catch (const std::exception& ex) {
+             parent_->isGckRetrievalInProgress_ = false;
              onError_(EncryptError::ErrorCode::CkRetrievalFailure,
                string("Error decoding GCK name in: ") + gckLatestData->getName().toUri());
              return;
            }
 
-           if (newGckName.equals(gckName_)) {
+           if (newGckName.equals(parent_->ckName_)) {
              // The latest is the same name, so do nothing.
              parent_->isGckRetrievalInProgress_ = false;
              return;
@@ -556,6 +557,7 @@ EncryptorV2::Impl::checkForNewGck(const EncryptError::OnError& onError)
            parent_->fetchGck(newGckName, onError_, N_RETRIES);
          },
          [=](auto&, auto& error) {
+           parent_->isGckRetrievalInProgress_ = false;
            onError_(EncryptError::ErrorCode::CkRetrievalFailure,
              "Validate GCK latest_ Data failure: " + error.toString());
          });
@@ -582,7 +584,6 @@ EncryptorV2::Impl::checkForNewGck(const EncryptError::OnError& onError)
     }
 
     ptr_lib::shared_ptr<Impl> parent_;
-    Name gckName_;
     EncryptError::OnError onError_;
   };
 


### PR DESCRIPTION
On pull request #9, we added support for secured Interest and GCK, but we didn't update the CHANGELOG. Also, when porting to JavaScript, I found some minor errors in the C++ code.

This pull request has five small commits. The first commit fixes an error message for decrypting an Interest.

The second commit corrects the internal method `DecryptorV2::fetchGck` to behave like `fetchCk` by clearing the pendingInterest ID as soon as a Data packet is received (and not wait for it to be validated).

The third commit fixes the spelling of the API method `EncryptorV2::setcheckForNewGckInterval` to `setCheckForNewGckInterval` . (These is a convenience method to override a default. No example code currently calls it, so no other code needs to be changed.)

The fourth commit fixes a bug in `EncryptorV2::checkForNewGck` which gets the latest group content key name from the Access Manager and checks if it has changed from the one that the EncryptorV2 already has. It was checking the wrong variable, and so updated the content key at each check. This bug was not causing errors, but should be fixed.

Finally, the fifth commit updates the CHANGELOG which we didn't do in pull request #9.