### PR TITLE
In Transport add optional flag readRawPackets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2020-11-10)
+NDN-IND (2020-11-19)
 --------------------
 
 Changes
@@ -21,6 +21,7 @@ Changes
 * In KeyChain, remove obsolete security v1 API. https://github.com/operantnetworks/ndn-ind/issues/1
 * Remove obsolete Name-based Access Control v1. (Keep v2.)
 * PIB and TPM: Change system() to mkdir() or create_directories(). https://github.com/operantnetworks/ndn-ind/pull/15
+* In Transport, added readRawPackets to handle raw packets. https://github.com/operantnetworks/ndn-ind/pull/16
 * In examples and unit tests, use the default Face which doesn't require TCP.
 * Move the instructions for RHEL 7 to the wiki.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ check_PROGRAMS = bin/unit-tests/test-access-manager-v2 \
 
 noinst_PROGRAMS = bin/test-access-manager bin/test-channel-discovery bin/test-chrono-chat \
   bin/test-custom-tpm bin/test-echo-consumer bin/test-echo-consumer-lite \
+  bin/test-custom-tpm bin/test-echo-consumer-raw-tcp \
   bin/test-encode-decode-benchmark bin/test-encode-decode-data \
   bin/test-encode-decode-fib-entry bin/test-encode-decode-interest \
   bin/test-full-psync-with-users bin/test-full-psync \
@@ -522,6 +523,9 @@ bin_test_custom_tpm_LDADD = libndn-ind.la
 
 bin_test_echo_consumer_lite_SOURCES = examples/test-echo-consumer-lite.cpp
 bin_test_echo_consumer_lite_LDADD = libndn-ind.la
+
+bin_test_echo_consumer_raw_tcp_SOURCES = examples/test-echo-consumer-raw-tcp.cpp
+bin_test_echo_consumer_raw_tcp_LDADD = libndn-ind.la
 
 bin_test_echo_consumer_SOURCES = examples/test-echo-consumer.cpp
 bin_test_echo_consumer_LDADD = libndn-ind.la

--- a/Makefile.in
+++ b/Makefile.in
@@ -128,6 +128,8 @@ noinst_PROGRAMS = bin/test-access-manager$(EXEEXT) \
 	bin/test-chrono-chat$(EXEEXT) bin/test-custom-tpm$(EXEEXT) \
 	bin/test-echo-consumer$(EXEEXT) \
 	bin/test-echo-consumer-lite$(EXEEXT) \
+	bin/test-custom-tpm$(EXEEXT) \
+	bin/test-echo-consumer-raw-tcp$(EXEEXT) \
 	bin/test-encode-decode-benchmark$(EXEEXT) \
 	bin/test-encode-decode-data$(EXEEXT) \
 	bin/test-encode-decode-fib-entry$(EXEEXT) \
@@ -449,6 +451,11 @@ am_bin_test_echo_consumer_lite_OBJECTS =  \
 bin_test_echo_consumer_lite_OBJECTS =  \
 	$(am_bin_test_echo_consumer_lite_OBJECTS)
 bin_test_echo_consumer_lite_DEPENDENCIES = libndn-ind.la
+am_bin_test_echo_consumer_raw_tcp_OBJECTS =  \
+	examples/test-echo-consumer-raw-tcp.$(OBJEXT)
+bin_test_echo_consumer_raw_tcp_OBJECTS =  \
+	$(am_bin_test_echo_consumer_raw_tcp_OBJECTS)
+bin_test_echo_consumer_raw_tcp_DEPENDENCIES = libndn-ind.la
 am_bin_test_encode_decode_benchmark_OBJECTS =  \
 	examples/test-encode-decode-benchmark.$(OBJEXT)
 bin_test_encode_decode_benchmark_OBJECTS =  \
@@ -781,6 +788,7 @@ am__depfiles_remade = contrib/apache/$(DEPDIR)/apr_base64.Plo \
 	examples/$(DEPDIR)/test-chrono-chat.Po \
 	examples/$(DEPDIR)/test-custom-tpm.Po \
 	examples/$(DEPDIR)/test-echo-consumer-lite.Po \
+	examples/$(DEPDIR)/test-echo-consumer-raw-tcp.Po \
 	examples/$(DEPDIR)/test-echo-consumer.Po \
 	examples/$(DEPDIR)/test-encode-decode-benchmark.Po \
 	examples/$(DEPDIR)/test-encode-decode-data.Po \
@@ -1097,6 +1105,7 @@ SOURCES = $(libndn_c_la_SOURCES) $(libndn_ind_tools_la_SOURCES) \
 	$(bin_test_chrono_chat_SOURCES) $(bin_test_custom_tpm_SOURCES) \
 	$(bin_test_echo_consumer_SOURCES) \
 	$(bin_test_echo_consumer_lite_SOURCES) \
+	$(bin_test_echo_consumer_raw_tcp_SOURCES) \
 	$(bin_test_encode_decode_benchmark_SOURCES) \
 	$(bin_test_encode_decode_data_SOURCES) \
 	$(bin_test_encode_decode_fib_entry_SOURCES) \
@@ -1151,6 +1160,7 @@ DIST_SOURCES = $(libndn_c_la_SOURCES) $(libndn_ind_tools_la_SOURCES) \
 	$(bin_test_chrono_chat_SOURCES) $(bin_test_custom_tpm_SOURCES) \
 	$(bin_test_echo_consumer_SOURCES) \
 	$(bin_test_echo_consumer_lite_SOURCES) \
+	$(bin_test_echo_consumer_raw_tcp_SOURCES) \
 	$(bin_test_encode_decode_benchmark_SOURCES) \
 	$(bin_test_encode_decode_data_SOURCES) \
 	$(bin_test_encode_decode_fib_entry_SOURCES) \
@@ -2132,6 +2142,8 @@ bin_test_custom_tpm_SOURCES = examples/test-custom-tpm.cpp
 bin_test_custom_tpm_LDADD = libndn-ind.la
 bin_test_echo_consumer_lite_SOURCES = examples/test-echo-consumer-lite.cpp
 bin_test_echo_consumer_lite_LDADD = libndn-ind.la
+bin_test_echo_consumer_raw_tcp_SOURCES = examples/test-echo-consumer-raw-tcp.cpp
+bin_test_echo_consumer_raw_tcp_LDADD = libndn-ind.la
 bin_test_echo_consumer_SOURCES = examples/test-echo-consumer.cpp
 bin_test_echo_consumer_LDADD = libndn-ind.la
 bin_test_encode_decode_benchmark_SOURCES = examples/test-encode-decode-benchmark.cpp
@@ -3195,6 +3207,12 @@ examples/test-echo-consumer-lite.$(OBJEXT): examples/$(am__dirstamp) \
 bin/test-echo-consumer-lite$(EXEEXT): $(bin_test_echo_consumer_lite_OBJECTS) $(bin_test_echo_consumer_lite_DEPENDENCIES) $(EXTRA_bin_test_echo_consumer_lite_DEPENDENCIES) bin/$(am__dirstamp)
 	@rm -f bin/test-echo-consumer-lite$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(bin_test_echo_consumer_lite_OBJECTS) $(bin_test_echo_consumer_lite_LDADD) $(LIBS)
+examples/test-echo-consumer-raw-tcp.$(OBJEXT):  \
+	examples/$(am__dirstamp) examples/$(DEPDIR)/$(am__dirstamp)
+
+bin/test-echo-consumer-raw-tcp$(EXEEXT): $(bin_test_echo_consumer_raw_tcp_OBJECTS) $(bin_test_echo_consumer_raw_tcp_DEPENDENCIES) $(EXTRA_bin_test_echo_consumer_raw_tcp_DEPENDENCIES) bin/$(am__dirstamp)
+	@rm -f bin/test-echo-consumer-raw-tcp$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(bin_test_echo_consumer_raw_tcp_OBJECTS) $(bin_test_echo_consumer_raw_tcp_LDADD) $(LIBS)
 examples/test-encode-decode-benchmark.$(OBJEXT):  \
 	examples/$(am__dirstamp) examples/$(DEPDIR)/$(am__dirstamp)
 
@@ -3835,6 +3853,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-chrono-chat.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-custom-tpm.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-echo-consumer-lite.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-echo-consumer-raw-tcp.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-echo-consumer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-encode-decode-benchmark.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/test-encode-decode-data.Po@am__quote@ # am--include-marker
@@ -6257,6 +6276,7 @@ distclean: distclean-recursive
 	-rm -f examples/$(DEPDIR)/test-chrono-chat.Po
 	-rm -f examples/$(DEPDIR)/test-custom-tpm.Po
 	-rm -f examples/$(DEPDIR)/test-echo-consumer-lite.Po
+	-rm -f examples/$(DEPDIR)/test-echo-consumer-raw-tcp.Po
 	-rm -f examples/$(DEPDIR)/test-echo-consumer.Po
 	-rm -f examples/$(DEPDIR)/test-encode-decode-benchmark.Po
 	-rm -f examples/$(DEPDIR)/test-encode-decode-data.Po
@@ -6633,6 +6653,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f examples/$(DEPDIR)/test-chrono-chat.Po
 	-rm -f examples/$(DEPDIR)/test-custom-tpm.Po
 	-rm -f examples/$(DEPDIR)/test-echo-consumer-lite.Po
+	-rm -f examples/$(DEPDIR)/test-echo-consumer-raw-tcp.Po
 	-rm -f examples/$(DEPDIR)/test-echo-consumer.Po
 	-rm -f examples/$(DEPDIR)/test-encode-decode-benchmark.Po
 	-rm -f examples/$(DEPDIR)/test-encode-decode-data.Po

--- a/examples/test-echo-consumer-raw-tcp.cpp
+++ b/examples/test-echo-consumer-raw-tcp.cpp
@@ -1,0 +1,115 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+/**
+ * This is similar to test-echo-consumer, but demonstrates how to use
+ * TcpTransport directly with raw packets. You would not normally do this in an
+ * NDN application. But this example is here to show the flexibility of
+ * TcpTransport.
+ *
+ * This is meant to work with test-publish-async-nfd. This sends encodes an
+ * Interest and sends it to the TCP socket which is connected to NFD.
+ * Then this waits for a packet that it decodes as a Data packet.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <unistd.h>
+#include <ndn-ind/interest.hpp>
+#include <ndn-ind/transport/tcp-transport.hpp>
+
+using namespace std;
+using namespace ndn;
+
+/**
+ * MyElementListener extends ElementListener and overrides onReceivedElement
+ * which is called by the Transport when a packet is received.
+ */
+class MyElementListener : public ElementListener {
+public:
+  MyElementListener() {
+    callbackCount_ = 0;
+  }
+
+  virtual void
+    onReceivedElement(const uint8_t *element, size_t elementLength)
+  {
+    ++callbackCount_;
+
+    // Process the raw incoming packet.
+    // For simplicity, assume that this is the response Data packet from
+    // test-publish-async-nfd, so decode as a Data packet.
+    // In a production application, we would check the format of the bytes
+    // in the packet and do error handling.
+    auto data = ptr_lib::make_shared<Data>();
+    data->wireDecode(element, elementLength);
+    cout << "Got data packet with name " << data->getName().toUri() << endl;
+    cout << data->getContent().toRawStr() << endl;
+  }
+
+  int callbackCount_;
+};
+
+int main(int argc, char** argv)
+{
+  // Silence the warning from Interest wire encode.
+  Interest::setDefaultCanBePrefix(true);
+
+  string word;
+  cout << "Enter a word to echo:" << endl;
+  cin >> word;
+
+  // Create a TcpTransport with readRawPackets true.
+  auto transport = ptr_lib::make_shared<TcpTransport>(true);
+  auto host = "localhost";
+
+  // Make the ElementListener which has our onReceivedElement callback.
+  MyElementListener elementListener;
+
+  // Connect to the NFD at the host address. Provide the onConnected callback
+  // this is called when if finishes opening the TCP connection.
+  transport->connect
+    (TcpTransport::ConnectionInfo(host), elementListener,
+     [=]() {
+       // This is the onConnected callback. Create an interest /testecho/<word>.
+       Name name("/testecho");
+       name.append(word);
+       Interest interest(name);
+       cout << "Express name " << name.toUri() << endl;
+
+       // We are using the raw TcpTransport directly so we must encode the Interest.
+       Blob encoding = interest.wireEncode();
+       transport->send(encoding.buf(), encoding.size());
+     });
+
+  // The main event loop. Loop until onReceivedElement increments callbackCount_.
+  while (elementListener.callbackCount_ < 1) {
+    // Call processEvents which polls the socket. If there is no incoming data,
+    // processEvents returns immediately, otherwise it reads the incoming data
+    // and calls the onReceivedElement method of the ElementListener object
+    // given to Transport connect.
+    transport->processEvents();
+    // We need to sleep for a few milliseconds so we don't use 100% of the CPU.
+    usleep(10000);
+  }
+
+  return 0;
+}

--- a/include/ndn-ind/c/encoding/element-reader-types.h
+++ b/include/ndn-ind/c/encoding/element-reader-types.h
@@ -1,4 +1,16 @@
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/c/encoding/element-reader-types.h
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -55,14 +67,16 @@ struct ndn_TlvStructureDecoder {
  * ndn_TlvStructureDecoder as needed to detect the end of a TLV element,
  * and calls (*elementListener->onReceivedElement)(element, elementLength) with the element.
  * This handles the case where a single call to onReceivedData may contain multiple elements.
+ * However, if readRawPackets is 1, then onReceivedElement for each received packet without processing.
  */
 struct ndn_ElementReader {
   struct ndn_ElementListener *elementListener;
-  struct ndn_TlvStructureDecoder tlvStructureDecoder;
-  int usePartialData;       /**< boolean */
-  int gotPartialDataError;  /**< boolean. Only meaningful if usePartialData. */
-  struct ndn_DynamicUInt8Array* partialData;
-  size_t partialDataLength;
+  int readRawPackets;       /**< boolean */
+  struct ndn_TlvStructureDecoder tlvStructureDecoder; /**< Only used if readRawPackets == 0. */
+  int usePartialData;       /**< boolean. Only used if readRawPackets == 0. */
+  int gotPartialDataError;  /**< boolean. Only meaningful if usePartialData. Only used if readRawPackets == 0. */
+  struct ndn_DynamicUInt8Array* partialData; /**< Only used if readRawPackets == 0. */
+  size_t partialDataLength;                  /**< Only used if readRawPackets == 0. */
 };
 
 #ifdef __cplusplus

--- a/include/ndn-ind/encoding/element-listener.hpp
+++ b/include/ndn-ind/encoding/element-listener.hpp
@@ -8,7 +8,7 @@
  * Original file: src/encoding/element-listener.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -34,7 +34,7 @@
 #ifndef NDN_ELEMENT_LISTENER_HPP
 #define NDN_ELEMENT_LISTENER_HPP
 
-#include "../c/encoding/element-listener.h"
+#include <ndn-ind/c/encoding/element-reader-types.h>
 
 namespace ndn {
 
@@ -44,10 +44,7 @@ namespace ndn {
  */
 class ElementListener : public ndn_ElementListener {
 public:
-  ElementListener()
-  {
-    ndn_ElementListener_initialize(this, staticOnReceivedElement);
-  }
+  ElementListener();
 
   /**
    * This is called when an entire element is received.  You must extend this class to override this method.

--- a/include/ndn-ind/lite/encoding/element-listener-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-listener-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/lite/encoding/element-listener-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused transports.
+ * Summary of Changes: Remove unused transports. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -53,7 +53,9 @@ public:
    * @param onReceivedElement When an entire packet element is received, call
    * onReceivedElement(ElementListenerLite *self, uint8_t *element, size_t elementLength)
    * where self is the pointer to this object, and element is a pointer to the
-   * array of length elementLength with the bytes of the element. If you
+   * array of length elementLength with the bytes of the element. The element buffer is
+   * only valid during the call to onReceivedElement. If you need the data in the
+   * buffer after onReceivedElement returns, then you must copy it. If you
    * created a derived class, you can downcast self to a pointer to your derived
    * class in order to access its members.
    */

--- a/include/ndn-ind/lite/transport/tcp-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/tcp-transport-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/lite/transport/tcp-transport-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -44,8 +56,13 @@ public:
    * during the entire life of this object. If the reallocFunction given to
    * buffer's constructor is 0, then its array must be large enough to save a
    * full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+   * However, if readRawPackets is true, then the buffer is not used.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  TcpTransportLite(DynamicUInt8ArrayLite& buffer);
+  TcpTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting to the host is

--- a/include/ndn-ind/lite/transport/udp-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/udp-transport-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/lite/transport/udp-transport-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -44,8 +56,13 @@ public:
    * during the entire life of this object. If the reallocFunction given to
    * buffer's constructor is 0, then its array must be large enough to save a
    * full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+   * However, if readRawPackets is true, then the buffer is not used.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  UdpTransportLite(DynamicUInt8ArrayLite& buffer);
+  UdpTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets = false);
 
   /**
    * Determine whether this transport is to a node on the current machine.

--- a/include/ndn-ind/lite/transport/unix-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/unix-transport-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/lite/transport/unix-transport-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -45,8 +57,13 @@ public:
    * during the entire life of this object. If the reallocFunction given to
    * buffer's constructor is 0, then its array must be large enough to save a
    * full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+   * However, if readRawPackets is true, then the buffer is not used.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  UnixTransportLite(DynamicUInt8ArrayLite& buffer);
+  UnixTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets = false);
 
   /**
    * Determine whether this transport is to a node on the current machine.

--- a/include/ndn-ind/transport/async-tcp-transport.hpp
+++ b/include/ndn-ind/transport/async-tcp-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/transport/async-tcp-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -97,8 +97,13 @@ public:
    * ioService to create the connection and communicate asynchronously.
    * @param ioService The asio io_service. It is the responsibility of the
    * application to start and stop the service.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  AsyncTcpTransport(boost::asio::io_service& ioService);
+  AsyncTcpTransport
+    (boost::asio::io_service& ioService, bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting according to connectionInfo is

--- a/include/ndn-ind/transport/async-unix-transport.hpp
+++ b/include/ndn-ind/transport/async-unix-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/transport/async-unix-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -90,8 +90,13 @@ public:
    * ioService to create the connection and communicate asynchronously.
    * @param ioService The asio io_service. It is the responsibility of the
    * application to start and stop the service.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  AsyncUnixTransport(boost::asio::io_service& ioService);
+  AsyncUnixTransport
+    (boost::asio::io_service& ioService, bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting according to connectionInfo is

--- a/include/ndn-ind/transport/tcp-transport.hpp
+++ b/include/ndn-ind/transport/tcp-transport.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/transport/tcp-transport.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -76,7 +88,14 @@ public:
     unsigned short port_;
   };
 
-  TcpTransport();
+  /**
+   * Create a TcpTransport.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
+   */
+  TcpTransport(bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting according to connectionInfo is

--- a/include/ndn-ind/transport/transport.hpp
+++ b/include/ndn-ind/transport/transport.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/transport/transport.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Put element-listener.hpp in API.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -24,10 +36,9 @@
 
 #include <vector>
 #include "../common.hpp"
+#include "../encoding/element-listener.hpp"
 
 namespace ndn {
-
-class ElementListener;
 
 /**
  * A Transport object is used by Face to send packets and to listen for incoming

--- a/include/ndn-ind/transport/udp-transport.hpp
+++ b/include/ndn-ind/transport/udp-transport.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/transport/udp-transport.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -76,7 +88,14 @@ public:
     unsigned short port_;
   };
 
-  UdpTransport();
+  /**
+   * Create a UdpTransport.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
+   */
+  UdpTransport(bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting according to connectionInfo is

--- a/include/ndn-ind/transport/unix-transport.hpp
+++ b/include/ndn-ind/transport/unix-transport.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-ind/transport/unix-transport.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -67,7 +79,14 @@ public:
     std::string filePath_;
   };
 
-  UnixTransport();
+  /**
+   * Create a UnixTransport.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false or omitted, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
+   */
+  UnixTransport(bool readRawPackets = false);
 
   /**
    * Determine whether this transport connecting according to connectionInfo is

--- a/src/c/encoding/element-listener.h
+++ b/src/c/encoding/element-listener.h
@@ -7,7 +7,7 @@
  * Original file: src/c/encoding/element-listener.h
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -47,7 +47,9 @@ extern "C" {
  * @param onReceivedElement When an entire packet element is received, call
  * onReceivedElement(self, element, elementLength) where self is the pointer to
  * this ndn_ElementListener struct, and element is a pointer to the array of
- * length elementLength with the bytes of the element.
+ * length elementLength with the bytes of the element. The element buffer is
+ * only valid during the call to onReceivedElement. If you need the data in the
+ * buffer after onReceivedElement returns, then you must copy it.
  */
 static __inline void ndn_ElementListener_initialize
   (struct ndn_ElementListener *self, ndn_OnReceivedElement onReceivedElement)

--- a/src/c/encoding/element-reader.c
+++ b/src/c/encoding/element-reader.c
@@ -1,4 +1,16 @@
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/c/encoding/element-reader.c
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -24,6 +36,19 @@
 ndn_Error ndn_ElementReader_onReceivedData
   (struct ndn_ElementReader *self, const uint8_t *data, size_t dataLength)
 {
+  if (self->readRawPackets) {
+    // Just call onReceivedElement.
+    if (dataLength > 0) {
+      if (!self->elementListener)
+        return NDN_ERROR_ElementReader_ElementListener_is_not_specified;
+
+      (*self->elementListener->onReceivedElement)
+        (self->elementListener, data, dataLength);
+    }
+
+    return NDN_ERROR_success;
+  }
+
   // Process multiple objects in the data.
   while(1) {
     ndn_Error error;

--- a/src/c/encoding/element-reader.h
+++ b/src/c/encoding/element-reader.h
@@ -7,7 +7,7 @@
  * Original file: src/c/encoding/element-reader.h
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -53,12 +53,18 @@ extern "C" {
  * during the entire life of this ndn_ElementReader. If the buffer->realloc
  * function pointer is 0, its array must be large enough to save a full element,
  * perhaps MAX_NDN_PACKET_SIZE bytes.
+ * However, if readRawPackets is 1, then the buffer is not used.
+ * @param readRawPackets If 1, then call elementListener->onReceivedElement for
+ * each received packet as-is. If 0, then use the ndn_TlvStructureDecoder to
+ * ensure that elementListener->onReceivedElement is called once for a whole
+ * TLV packet.
  */
 static __inline void ndn_ElementReader_initialize
   (struct ndn_ElementReader *self, struct ndn_ElementListener *elementListener,
-   struct ndn_DynamicUInt8Array *buffer)
+   struct ndn_DynamicUInt8Array *buffer, int readRawPackets)
 {
   self->elementListener = elementListener;
+  self->readRawPackets = readRawPackets;
   ndn_TlvStructureDecoder_initialize(&self->tlvStructureDecoder);
   self->partialData = buffer;
   self->usePartialData = 0;

--- a/src/c/transport/socket-transport.h
+++ b/src/c/transport/socket-transport.h
@@ -7,7 +7,7 @@
  * Original file: src/c/transport/socket-transport.h
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -58,12 +58,18 @@ typedef enum {
  * The struct must remain valid during the entire life of this
  * ndn_SocketTransport. If the buffer->realloc function pointer is 0, its array
  * must be large enough to save a full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+ * However, if readRawPackets is 1, then the buffer is not used.
+ * @param readRawPackets If 1, then call elementListener->onReceivedElement for
+ * each received packet as-is. If 0, then use the ndn_TlvStructureDecoder to
+ * ensure that elementListener->onReceivedElement is called once for a whole
+ * TLV packet.
  */
 static __inline void ndn_SocketTransport_initialize
-  (struct ndn_SocketTransport *self, struct ndn_DynamicUInt8Array *buffer)
+  (struct ndn_SocketTransport *self, struct ndn_DynamicUInt8Array *buffer,
+   int readRawPackets)
 {
   self->socketDescriptor = -1;
-  ndn_ElementReader_initialize(&self->elementReader, 0, buffer);
+  ndn_ElementReader_initialize(&self->elementReader, 0, buffer, readRawPackets);
 }
 
 /**

--- a/src/c/transport/tcp-transport.h
+++ b/src/c/transport/tcp-transport.h
@@ -1,4 +1,16 @@
 /*
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/c/transport/tcp-transport.h
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -37,11 +49,17 @@ extern "C" {
  * The struct must remain valid during the entire life of this
  * ndn_SocketTransport. If the buffer->realloc function pointer is 0, its array
  * must be large enough to save a full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+ * However, if readRawPackets is 1, then the buffer is not used.
+ * @param readRawPackets If 1, then call elementListener->onReceivedElement for
+ * each received packet as-is. If 0, then use the ndn_TlvStructureDecoder to
+ * ensure that elementListener->onReceivedElement is called once for a whole
+ * TLV packet.
  */
 static __inline void ndn_TcpTransport_initialize
-  (struct ndn_TcpTransport *self, struct ndn_DynamicUInt8Array *buffer)
+  (struct ndn_TcpTransport *self, struct ndn_DynamicUInt8Array *buffer,
+   int readRawPackets)
 {
-  ndn_SocketTransport_initialize(&self->base, buffer);
+  ndn_SocketTransport_initialize(&self->base, buffer, readRawPackets);
 }
 
 /**

--- a/src/c/transport/udp-transport.h
+++ b/src/c/transport/udp-transport.h
@@ -1,4 +1,16 @@
 /*
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/c/transport/udp-transport.h
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -37,11 +49,17 @@ extern "C" {
  * The struct must remain valid during the entire life of this
  * ndn_SocketTransport. If the buffer->realloc function pointer is 0, its array
  * must be large enough to save a full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+ * However, if readRawPackets is 1, then the buffer is not used.
+ * @param readRawPackets If 1, then call elementListener->onReceivedElement for
+ * each received packet as-is. If 0, then use the ndn_TlvStructureDecoder to
+ * ensure that elementListener->onReceivedElement is called once for a whole
+ * TLV packet.
  */
 static __inline void ndn_UdpTransport_initialize
-  (struct ndn_UdpTransport *self, struct ndn_DynamicUInt8Array *buffer)
+  (struct ndn_UdpTransport *self, struct ndn_DynamicUInt8Array *buffer,
+   int readRawPackets)
 {
-  ndn_SocketTransport_initialize(&self->base, buffer);
+  ndn_SocketTransport_initialize(&self->base, buffer, readRawPackets);
 }
 
 /**

--- a/src/c/transport/unix-transport.h
+++ b/src/c/transport/unix-transport.h
@@ -1,4 +1,16 @@
 /*
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/c/transport/unix-transport.h
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -37,11 +49,17 @@ extern "C" {
  * The struct must remain valid during the entire life of this
  * ndn_SocketTransport. If the buffer->realloc function pointer is 0, its array
  * must be large enough to save a full element, perhaps MAX_NDN_PACKET_SIZE bytes.
+ * However, if readRawPackets is 1, then the buffer is not used.
+ * @param readRawPackets If 1, then call elementListener->onReceivedElement for
+ * each received packet as-is. If 0, then use the ndn_TlvStructureDecoder to
+ * ensure that elementListener->onReceivedElement is called once for a whole
+ * TLV packet.
  */
 static __inline void ndn_UnixTransport_initialize
-  (struct ndn_UnixTransport *self, struct ndn_DynamicUInt8Array *buffer)
+  (struct ndn_UnixTransport *self, struct ndn_DynamicUInt8Array *buffer,
+   int readRawPackets)
 {
-  ndn_SocketTransport_initialize(&self->base, buffer);
+  ndn_SocketTransport_initialize(&self->base, buffer, readRawPackets);
 }
 
 /**

--- a/src/encoding/element-listener.cpp
+++ b/src/encoding/element-listener.cpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/encoding/element-listener.cpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Put element-listener.hpp in API.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -19,9 +31,15 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
-#include "element-listener.hpp"
+#include "../c/encoding/element-listener.h"
+#include <ndn-ind/encoding/element-listener.hpp>
 
 namespace ndn {
+
+ElementListener::ElementListener()
+{
+  ndn_ElementListener_initialize(this, staticOnReceivedElement);
+}
 
 void
 ElementListener::staticOnReceivedElement(struct ndn_ElementListener *self, const uint8_t *element, size_t elementLength)

--- a/src/encoding/element-listener.hpp
+++ b/src/encoding/element-listener.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: src/encoding/element-listener.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Add readRawPackets.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -39,8 +51,9 @@ public:
 
   /**
    * This is called when an entire element is received.  You must extend this class to override this method.
-   * @param element pointer to the element.  This buffer is only valid during this call.  If you need the data
-   * later, you must copy.
+   * @param element pointer to the element. The element buffer is
+   * only valid during the call to onReceivedElement. If you need the data in the
+   * buffer after onReceivedElement returns, then you must copy it.
    * @param elementLength length of element
    */
   virtual void

--- a/src/lite/transport/tcp-transport-lite.cpp
+++ b/src/lite/transport/tcp-transport-lite.cpp
@@ -8,7 +8,7 @@
  * Original file: src/lite/transport/tcp-transport-lite.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -40,9 +40,9 @@
 
 namespace ndn {
 
-TcpTransportLite::TcpTransportLite(DynamicUInt8ArrayLite& buffer)
+TcpTransportLite::TcpTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets)
 {
-  ndn_TcpTransport_initialize(this, &buffer);
+  ndn_TcpTransport_initialize(this, &buffer, readRawPackets ? 1 : 0);
 }
 
 ndn_Error

--- a/src/lite/transport/udp-transport-lite.cpp
+++ b/src/lite/transport/udp-transport-lite.cpp
@@ -8,7 +8,7 @@
  * Original file: src/lite/transport/udp-transport-lite.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -40,9 +40,9 @@
 
 namespace ndn {
 
-UdpTransportLite::UdpTransportLite(DynamicUInt8ArrayLite& buffer)
+UdpTransportLite::UdpTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets)
 {
-  ndn_UdpTransport_initialize(this, &buffer);
+  ndn_UdpTransport_initialize(this, &buffer, readRawPackets ? 1 : 0);
 }
 
 bool

--- a/src/lite/transport/unix-transport-lite.cpp
+++ b/src/lite/transport/unix-transport-lite.cpp
@@ -8,7 +8,7 @@
  * Original file: src/lite/transport/unix-transport-lite.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -40,9 +40,9 @@
 
 namespace ndn {
 
-UnixTransportLite::UnixTransportLite(DynamicUInt8ArrayLite& buffer)
+UnixTransportLite::UnixTransportLite(DynamicUInt8ArrayLite& buffer, bool readRawPackets)
 {
-  ndn_UnixTransport_initialize(this, &buffer);
+  ndn_UnixTransport_initialize(this, &buffer, readRawPackets ? 1 : 0);
 }
 
 bool

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -8,7 +8,7 @@
  * Original file: src/node.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Use std::chrono.
+ * Summary of Changes: Use NDN_IND macros. Use std::chrono. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -49,7 +49,6 @@
 #include "impl/interest-filter-table.hpp"
 #include "impl/pending-interest-table.hpp"
 #include "impl/registered-prefix-table.hpp"
-#include "encoding/element-listener.hpp"
 
 struct ndn_Interest;
 

--- a/src/transport/async-socket-transport.hpp
+++ b/src/transport/async-socket-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/async-socket-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -60,9 +60,13 @@ public:
    * ioService to create the connection and communicate asynchronously.
    * @param ioService The asio io_service. It is the responsibility of the
    * application to start and stop the service.
+   * @param readRawPackets If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If
+   * false, then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
    */
-  AsyncSocketTransport(boost::asio::io_service& ioService)
-  : impl_(new Impl(ioService))
+  AsyncSocketTransport(boost::asio::io_service& ioService, bool readRawPackets)
+  : impl_(new Impl(ioService, readRawPackets))
   {
   }
 
@@ -121,11 +125,12 @@ private:
    */
   class Impl : public boost::enable_shared_from_this<Impl> {
   public:
-    Impl(boost::asio::io_service& ioService)
+    Impl(boost::asio::io_service& ioService, bool readRawPackets)
     : ioService_(ioService), socket_(new typename AsioProtocol::socket(ioService)),
       elementBuffer_(new DynamicUInt8Vector(1000)), isConnected_(false)
     {
-      ndn_ElementReader_initialize(&elementReader_, 0, elementBuffer_.get());
+      ndn_ElementReader_initialize
+        (&elementReader_, 0, elementBuffer_.get(), readRawPackets);
     }
 
     /**

--- a/src/transport/async-socket-transport.hpp
+++ b/src/transport/async-socket-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/async-socket-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -40,7 +40,6 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <ndn-ind/transport/transport.hpp>
 #include "../c/encoding/element-reader.h"
-#include "../encoding/element-listener.hpp"
 #include "../util/dynamic-uint8-vector.hpp"
 
 namespace ndn {

--- a/src/transport/async-tcp-transport.cpp
+++ b/src/transport/async-tcp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/async-tcp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -59,8 +59,8 @@ namespace ndn {
 class AsyncTcpTransport::SocketTransport
   : public AsyncSocketTransport<boost::asio::ip::tcp> {
 public:
-  SocketTransport(boost::asio::io_service& ioService)
-  : AsyncSocketTransport(ioService)
+  SocketTransport(boost::asio::io_service& ioService, bool readRawPackets)
+  : AsyncSocketTransport(ioService, readRawPackets)
   {
   }
 };
@@ -69,8 +69,9 @@ AsyncTcpTransport::ConnectionInfo::~ConnectionInfo()
 {
 }
 
-AsyncTcpTransport::AsyncTcpTransport(boost::asio::io_service& ioService)
-: ioService_(ioService), socketTransport_(new SocketTransport(ioService)),
+AsyncTcpTransport::AsyncTcpTransport
+  (boost::asio::io_service& ioService, bool readRawPackets)
+: ioService_(ioService), socketTransport_(new SocketTransport(ioService, readRawPackets)),
   connectionInfo_("", 0)
 {
 }

--- a/src/transport/async-tcp-transport.cpp
+++ b/src/transport/async-tcp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/async-tcp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -39,7 +39,6 @@
 #include <boost/bind.hpp>
 #include "../c/transport/tcp-transport.h"
 #include "../c/encoding/element-reader.h"
-#include "../encoding/element-listener.hpp"
 #include "../util/dynamic-uint8-vector.hpp"
 #include "async-socket-transport.hpp"
 #include <ndn-ind/transport/async-tcp-transport.hpp>

--- a/src/transport/async-unix-transport.cpp
+++ b/src/transport/async-unix-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/async-unix-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -53,9 +53,10 @@ AsyncUnixTransport::ConnectionInfo::~ConnectionInfo()
 {
 }
 
-AsyncUnixTransport::AsyncUnixTransport(boost::asio::io_service& ioService)
+AsyncUnixTransport::AsyncUnixTransport
+  (boost::asio::io_service& ioService, bool readRawPackets)
 : socketTransport_(new AsyncSocketTransport<boost::asio::local::stream_protocol>
-                   (ioService))
+                   (ioService, readRawPackets))
 {
 }
 

--- a/src/transport/tcp-transport.cpp
+++ b/src/transport/tcp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/tcp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include "../c/transport/tcp-transport.h"
 #include "../c/encoding/element-reader.h"
-#include "../encoding/element-listener.hpp"
 #include "../util/dynamic-uint8-vector.hpp"
 #include <ndn-ind/transport/tcp-transport.hpp>
 

--- a/src/transport/tcp-transport.cpp
+++ b/src/transport/tcp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/tcp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,11 +51,12 @@ TcpTransport::ConnectionInfo::~ConnectionInfo()
 {
 }
 
-TcpTransport::TcpTransport()
+TcpTransport::TcpTransport(bool readRawPackets)
   : isConnected_(false), transport_(new struct ndn_TcpTransport),
     elementBuffer_(new DynamicUInt8Vector(1000)), connectionInfo_("", 0)
 {
-  ndn_TcpTransport_initialize(transport_.get(), elementBuffer_.get());
+  ndn_TcpTransport_initialize
+    (transport_.get(), elementBuffer_.get(), readRawPackets ? 1 : 0);
 }
 
 bool

--- a/src/transport/udp-transport.cpp
+++ b/src/transport/udp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/udp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include "../c/transport/udp-transport.h"
 #include "../c/encoding/element-reader.h"
-#include "../encoding/element-listener.hpp"
 #include "../util/dynamic-uint8-vector.hpp"
 #include <ndn-ind/transport/udp-transport.hpp>
 

--- a/src/transport/udp-transport.cpp
+++ b/src/transport/udp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/udp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,11 +51,12 @@ UdpTransport::ConnectionInfo::~ConnectionInfo()
 {
 }
 
-UdpTransport::UdpTransport()
+UdpTransport::UdpTransport(bool readRawPackets)
   : isConnected_(false), transport_(new struct ndn_UdpTransport),
     elementBuffer_(new DynamicUInt8Vector(1000))
 {
-  ndn_UdpTransport_initialize(transport_.get(), elementBuffer_.get());
+  ndn_UdpTransport_initialize
+    (transport_.get(), elementBuffer_.get(), readRawPackets ? 1 : 0);
 }
 
 bool

--- a/src/transport/unix-transport.cpp
+++ b/src/transport/unix-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/unix-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,11 +51,12 @@ UnixTransport::ConnectionInfo::~ConnectionInfo()
 {
 }
 
-UnixTransport::UnixTransport()
+UnixTransport::UnixTransport(bool readRawPackets)
   : isConnected_(false), transport_(new struct ndn_UnixTransport),
     elementBuffer_(new DynamicUInt8Vector(1000))
 {
-  ndn_UnixTransport_initialize(transport_.get(), elementBuffer_.get());
+  ndn_UnixTransport_initialize
+    (transport_.get(), elementBuffer_.get(), readRawPackets);
 }
 
 bool

--- a/src/transport/unix-transport.cpp
+++ b/src/transport/unix-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/unix-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include "../c/transport/unix-transport.h"
 #include "../c/encoding/element-reader.h"
-#include "../encoding/element-listener.hpp"
 #include "../util/dynamic-uint8-vector.hpp"
 #include <ndn-ind/transport/unix-transport.hpp>
 


### PR DESCRIPTION
The NDN-IND Transport class is used for all communication and is integrated with the main processing loop. It has subclasses like TcpTransport. It has the ability to make a connection with a callback which is called on incoming data. The processEvents method efficiently polls the socket to check for incoming data. So, we want to use this class for other transport besides NDN packets. Currently, the Transport classes expect to read a NDN encoded packet. We want to add a flag `readRawPackets` to allow it to read any incoming packet.

This pull request has three commits. The first commit [updates element-reader.c](https://github.com/operantnetworks/ndn-ind/blob/9e9bfce1d54c9c7682c68dfcf132a32be449d3bd/src/c/encoding/element-reader.c#L39-L50) to check the `readRawPackets` flag. If true, then it calls the callback with the received packet instead of making sure that it has the NDN packet format. The rest of the changes in this commit simply propagate this flag up to the constructor for Transport and its subclasses (and updates the doc comments).

The second commit moves the header file for ElementListener to the public API. This allows an application to create a Transport and [call its connect method](https://github.com/operantnetworks/ndn-ind/blob/af7032d2ff88fe65ce33d7c1db3aca342a0670cb/include/ndn-ind/transport/tcp-transport.hpp#L132-L134) directly and use the Transport independent of the rest of the NDN-IND library.

The third commit adds the example program test-echo-consumer-raw-tcp to show how to [use TcpTransport directly](https://github.com/operantnetworks/ndn-ind/blob/de1bbc3143e4ee1e81e24df248e54a7c315a85bf/examples/test-echo-consumer-raw-tcp.cpp#L23-L30).