### PR TITLE
Build Windows ndn-ind.dll with Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 bin/*
 libs/*
 .libs/*
+VisualStudio/ndn-ind/.vs/*
+VisualStudio/ndn-ind/x64/*
+VisualStudio/example/.vs/*
+VisualStudio/example/x64/*
+*.user
 
 # Emacs temp files
 *~

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2020-11-19)
+NDN-IND (2020-12-08)
 --------------------
 
 Changes
@@ -24,6 +24,7 @@ Changes
 * In Transport, added readRawPackets to handle raw packets. https://github.com/operantnetworks/ndn-ind/pull/16
 * In examples and unit tests, use the default Face which doesn't require TCP.
 * Move the instructions for RHEL 7 to the wiki.
+* Add support for Visual Studio. https://github.com/operantnetworks/ndn-ind/pull/17
 
 Bug fixes
 * In expressInterest, use the nonce in the Interest if provided.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,10 @@ Following are the detailed steps for each platform to install the prerequisites.
 
 See the wiki page https://github.com/operantnetworks/ndn-ind/wiki/Install-NDN-dependencies-on-RHEL-7
 
+## Visual Studio
+
+To build on Windows with Visual Studio, see VisualStudio/Visual-Studio-README.md
+
 ## 10.9.5, OS X 10.10.2, OS X 10.11, macOS 10.12, macOS 10.13 and macOS 10.14
 Install Xcode. To install the command line tools, in a terminal enter:
 

--- a/VisualStudio/Visual-Studio-README.md
+++ b/VisualStudio/Visual-Studio-README.md
@@ -1,0 +1,46 @@
+NDN-IND for Visual Studio
+=========================
+
+## vcpkg
+
+* Install vcpkg from https://docs.microsoft.com/en-us/cpp/build/vcpkg?view=msvc-160#installation .
+* To install openssl, in a command prompt change directory to the vcpgk root and enter:
+
+    vcpkg install openssl:x64-Windows
+
+* To add the vcpkg to the path:
+    * In the Sytem control panel, click Advanced system settings, then click Environment Variables.
+    * In the "System variables" panel, click Path. Click Edit and click New.
+    * Enter the vcpkg bin folder, for example
+      `C:\Users\user\Documents\GitHub\vcpkg\installed\x64-windows\bin`.
+    * Click OK to close the control panels.
+    * If Visual Studio is already open, then close and re-open it to get the updated Path.
+
+## ndn-ind.dll
+
+To build ndn-ind.dll:
+
+* Copy `ndn-ind-config.h` from this folder to `include\ndn-ind` in the ndn-ind repository. 
+  (This file would normally be created on Unix by running ./configure .)
+* In Visual Studio, open `VisualStudio\ndn-ind\ndn-ind.sln` .
+* In the toolbar, select the configuration Release x64.
+* Right-click on the ndn-ind project and select Properties. Make sure it is set to 
+  the configuration Release x64. Under Linker/All Options, open 
+  Additional Library Directories. Make sure the directory for `vcpkg\installed\x64-windows\lib`
+  is correct. (If you cloned vcpkg in a sibling folder to ndn-ind, then it should be correct.)
+  Close the Properties window.
+* In the Build menu, click Build Solution.
+
+## Example program
+
+To build an example program and test ndn-ind.dll:
+
+* In Visual Studio, open `VisualStudio\example\example.sln`
+* In the toolbar, select the configuration Release x64.
+* In the Build menu, click Build Solution.
+* Copy `ndn-ind.dll` from the NDN-IND build folder to the application build folder. For
+  example, copy `C:\Users\user\Documents\GitHub\ndn-ind\VisualStudio\ndn-ind\x64\Release\ndn-ind.dll`
+  to `C:\Users\user\Documents\GitHub\ndn-ind\VisualStudio\example\x64\Release` .
+* To run, in the Debug menu, click Start Without Debugging. The default example is
+  `test-encode-decode-data.cpp`. You should see example encoding and decoding finishing with
+  "Freshly-signed Data signature verification: VERIFIED".

--- a/VisualStudio/example/example.sln
+++ b/VisualStudio/example/example.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30709.132
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example", "example.vcxproj", "{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Debug|x64.ActiveCfg = Debug|x64
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Debug|x64.Build.0 = Debug|x64
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Debug|x86.ActiveCfg = Debug|Win32
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Debug|x86.Build.0 = Debug|Win32
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Release|x64.ActiveCfg = Release|x64
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Release|x64.Build.0 = Release|x64
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Release|x86.ActiveCfg = Release|Win32
+		{3097FAD8-A2AF-4FF0-B309-64BEC4E78810}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7C40ECB0-D5A3-4F7C-940F-421DB7D94077}
+	EndGlobalSection
+EndGlobal

--- a/VisualStudio/example/example.vcxproj
+++ b/VisualStudio/example/example.vcxproj
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\examples\test-encode-decode-data.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{3097fad8-a2af-4ff0-b309-64bec4e78810}</ProjectGuid>
+    <RootNamespace>example</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ndn-ind.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\ndn-ind\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ndn-ind.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/VisualStudio/example/example.vcxproj
+++ b/VisualStudio/example/example.vcxproj
@@ -145,7 +145,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\ndn-ind\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ndn-ind.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ndn-ind.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualStudio/example/example.vcxproj.filters
+++ b/VisualStudio/example/example.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\examples\test-encode-decode-data.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/VisualStudio/ndn-ind-config.h
+++ b/VisualStudio/ndn-ind-config.h
@@ -1,0 +1,350 @@
+#ifndef _INCLUDE_NDN_IND_NDN_IND_CONFIG_H
+#define _INCLUDE_NDN_IND_NDN_IND_CONFIG_H 1
+ 
+/* include/ndn-ind/ndn-ind-config.h. Generated automatically at end of configure. */
+/* include/config.h.  Generated from config.h.in by configure.  */
+/* include/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* 1 if have `__attribute__((deprecated))'. */
+#ifndef NDN_IND_HAVE_ATTRIBUTE_DEPRECATED
+#define NDN_IND_HAVE_ATTRIBUTE_DEPRECATED 0
+#endif
+
+/* define if the Boost library is available */
+/* #undef HAVE_BOOST */
+
+/* define if the Boost::ASIO library is available */
+/* #undef HAVE_BOOST_ASIO */
+
+/* 1 if have boost/atomic.hpp. */
+#ifndef NDN_IND_HAVE_BOOST_ATOMIC
+#define NDN_IND_HAVE_BOOST_ATOMIC 0
+#endif
+
+/* define if the Boost::Chrono library is available */
+/* #undef HAVE_BOOST_CHRONO */
+
+/* 1 if have the `boost::function' class. */
+#ifndef NDN_IND_HAVE_BOOST_FUNCTION
+#define NDN_IND_HAVE_BOOST_FUNCTION 0
+#endif
+
+/* define if the Boost::Regex library is available */
+/* #undef HAVE_BOOST_REGEX */
+
+/* 1 if have the `boost::shared_ptr' class. */
+#ifndef NDN_IND_HAVE_BOOST_SHARED_PTR
+#define NDN_IND_HAVE_BOOST_SHARED_PTR 0
+#endif
+
+/* define if the compiler supports basic C++11 syntax */
+#ifndef NDN_IND_HAVE_CXX11
+#define NDN_IND_HAVE_CXX11 1
+#endif
+
+/* define if the compiler supports basic C++14 syntax */
+#ifndef NDN_IND_HAVE_CXX14
+#define NDN_IND_HAVE_CXX14 1
+#endif
+
+/* define if the compiler supports basic C++17 syntax */
+#ifndef NDN_IND_HAVE_CXX17
+#define NDN_IND_HAVE_CXX17 1
+#endif
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#ifndef NDN_IND_HAVE_DLFCN_H
+#define NDN_IND_HAVE_DLFCN_H 1
+#endif
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#ifndef NDN_IND_HAVE_GETTIMEOFDAY
+#define NDN_IND_HAVE_GETTIMEOFDAY 1
+#endif
+
+/* 1 if have sys/time gmtime support including timegm. */
+#ifndef NDN_IND_HAVE_GMTIME_SUPPORT
+#define NDN_IND_HAVE_GMTIME_SUPPORT 0
+#endif
+
+/* 1 if have WinSock2 `htonll'. */
+#ifndef NDN_IND_HAVE_HTONLL
+#define NDN_IND_HAVE_HTONLL 1
+#endif
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#ifndef NDN_IND_HAVE_INTTYPES_H
+#define NDN_IND_HAVE_INTTYPES_H 1
+#endif
+
+/* 1 if have OpenSSL crypto lib version 1.0+. */
+#ifndef NDN_IND_HAVE_LIBCRYPTO
+#define NDN_IND_HAVE_LIBCRYPTO 1
+#endif
+
+/* 1 if have OpenSSL crypto lib version 1.1+. */
+#ifndef NDN_IND_HAVE_LIBCRYPTO_1_1
+#define NDN_IND_HAVE_LIBCRYPTO_1_1 1
+#endif
+
+/* Define to 1 if you have the `log4cxx' library (-llog4cxx). */
+/* #undef HAVE_LIBLOG4CXX */
+
+/* Define to 1 if you have the `protobuf' library (-lprotobuf). */
+/* #undef HAVE_LIBPROTOBUF */
+
+/* Define to 1 if you have the `pthread' library (-lpthread). */
+/* #undef HAVE_LIBPTHREAD */
+
+/* Define to 1 if you have the `sqlite3' library (-lsqlite3). */
+/* #undef HAVE_LIBSQLITE3 */
+
+/* Define to 1 if you have `z' library (-lz) */
+#ifndef NDN_IND_HAVE_LIBZ
+#define NDN_IND_HAVE_LIBZ 0
+#endif
+
+/* 1 if have log4cxx. */
+#ifndef NDN_IND_HAVE_LOG4CXX
+#define NDN_IND_HAVE_LOG4CXX 0
+#endif
+
+/* Define to 1 if you have the `memcmp' function. */
+#ifndef NDN_IND_HAVE_MEMCMP
+#define NDN_IND_HAVE_MEMCMP 1
+#endif
+
+/* Define to 1 if you have the `memcpy' function. */
+#ifndef NDN_IND_HAVE_MEMCPY
+#define NDN_IND_HAVE_MEMCPY 1
+#endif
+
+/* Define to 1 if you have the <memory.h> header file. */
+#ifndef NDN_IND_HAVE_MEMORY_H
+#define NDN_IND_HAVE_MEMORY_H 1
+#endif
+
+/* Define to 1 if you have the `memset' function. */
+#ifndef NDN_IND_HAVE_MEMSET
+#define NDN_IND_HAVE_MEMSET 1
+#endif
+
+/* 1 if have the OSX framework. */
+#ifndef NDN_IND_HAVE_OSX_SECURITY
+#define NDN_IND_HAVE_OSX_SECURITY 0
+#endif
+
+/* 1 if have Google Protobuf. */
+#ifndef NDN_IND_HAVE_PROTOBUF
+#define NDN_IND_HAVE_PROTOBUF 0
+#endif
+
+/* Define if you have POSIX threads libraries and header files. */
+/* #undef HAVE_PTHREAD */
+
+/* Define to 1 if you have the `round' function. */
+#ifndef NDN_IND_HAVE_ROUND
+#define NDN_IND_HAVE_ROUND 1
+#endif
+
+/* Have the SQLITE3 library */
+/* #undef HAVE_SQLITE3 */
+
+/* Define to 1 if you have the `sscanf' function. */
+#ifndef NDN_IND_HAVE_SSCANF
+#define NDN_IND_HAVE_SSCANF 1
+#endif
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#ifndef NDN_IND_HAVE_STDINT_H
+#define NDN_IND_HAVE_STDINT_H 1
+#endif
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#ifndef NDN_IND_HAVE_STDLIB_H
+#define NDN_IND_HAVE_STDLIB_H 1
+#endif
+
+/* 1 if have the `std::function' class. */
+#ifndef NDN_IND_HAVE_STD_FUNCTION
+#define NDN_IND_HAVE_STD_FUNCTION 1
+#endif
+
+/* 1 if have std::regex. */
+#ifndef NDN_IND_HAVE_STD_REGEX
+#define NDN_IND_HAVE_STD_REGEX 1
+#endif
+
+/* 1 if have the `std::shared_ptr' class. */
+#ifndef NDN_IND_HAVE_STD_SHARED_PTR
+#define NDN_IND_HAVE_STD_SHARED_PTR 1
+#endif
+
+/* Define to 1 if you have the `strchr' function. */
+#ifndef NDN_IND_HAVE_STRCHR
+#define NDN_IND_HAVE_STRCHR 1
+#endif
+
+/* Define to 1 if you have the <strings.h> header file. */
+#ifndef NDN_IND_HAVE_STRINGS_H
+#define NDN_IND_HAVE_STRINGS_H 1
+#endif
+
+/* Define to 1 if you have the <string.h> header file. */
+#ifndef NDN_IND_HAVE_STRING_H
+#define NDN_IND_HAVE_STRING_H 1
+#endif
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#ifndef NDN_IND_HAVE_SYS_STAT_H
+#define NDN_IND_HAVE_SYS_STAT_H 1
+#endif
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#ifndef NDN_IND_HAVE_SYS_TIME_H
+#define NDN_IND_HAVE_SYS_TIME_H 0
+#endif
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#ifndef NDN_IND_HAVE_SYS_TYPES_H
+#define NDN_IND_HAVE_SYS_TYPES_H 1
+#endif
+
+/* Define to 1 if you have the <time.h> header file. */
+#ifndef NDN_IND_HAVE_TIME_H
+#define NDN_IND_HAVE_TIME_H 1
+#endif
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#ifndef NDN_IND_HAVE_UNISTD_H
+#define NDN_IND_HAVE_UNISTD_H 0
+#endif
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#ifndef NDN_IND_LT_OBJDIR
+#define NDN_IND_LT_OBJDIR ".libs/"
+#endif
+
+/* Define to the address where bug reports for this package should be sent. */
+#ifndef NDN_IND_PACKAGE_BUGREPORT
+#define NDN_IND_PACKAGE_BUGREPORT "ndn-lib@lists.cs.ucla.edu"
+#endif
+
+/* Define to the full name of this package. */
+#ifndef NDN_IND_PACKAGE_NAME
+#define NDN_IND_PACKAGE_NAME "ndn-ind"
+#endif
+
+/* Define to the full name and version of this package. */
+#ifndef NDN_IND_PACKAGE_STRING
+#define NDN_IND_PACKAGE_STRING "ndn-ind 1.0"
+#endif
+
+/* Define to the one symbol short name of this package. */
+#ifndef NDN_IND_PACKAGE_TARNAME
+#define NDN_IND_PACKAGE_TARNAME "ndn-ind"
+#endif
+
+/* Define to the home page for this package. */
+#ifndef NDN_IND_PACKAGE_URL
+#define NDN_IND_PACKAGE_URL "https://github.com/operantnetworks/ndn-ind"
+#endif
+
+/* Define to the version of this package. */
+#ifndef NDN_IND_PACKAGE_VERSION
+#define NDN_IND_PACKAGE_VERSION "1.0"
+#endif
+
+/* Define to the necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Define to 1 if you have the ANSI C header files. */
+#ifndef NDN_IND_STDC_HEADERS
+#define NDN_IND_STDC_HEADERS 1
+#endif
+
+/* Define to 1 if func_lib should use boost::function, etc. if available */
+#ifndef NDN_IND_WITH_BOOST_FUNCTION
+#define NDN_IND_WITH_BOOST_FUNCTION 0
+#endif
+
+/* Define to 1 if ptr_lib should use boost::shared_ptr, etc. if available */
+#ifndef NDN_IND_WITH_BOOST_SHARED_PTR
+#define NDN_IND_WITH_BOOST_SHARED_PTR 0
+#endif
+
+/* Define to 1 if the OS X Keychain should be the default private key store.
+   */
+#ifndef NDN_IND_WITH_OSX_KEYCHAIN
+#define NDN_IND_WITH_OSX_KEYCHAIN 0
+#endif
+
+/* Define to 1 if func_lib should use std::function, etc. if available */
+#ifndef NDN_IND_WITH_STD_FUNCTION
+#define NDN_IND_WITH_STD_FUNCTION 1
+#endif
+
+/* Define to 1 if ptr_lib should use std::shared_ptr, etc. if available */
+#ifndef NDN_IND_WITH_STD_SHARED_PTR
+#define NDN_IND_WITH_STD_SHARED_PTR 1
+#endif
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT64_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to the type of a signed integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int16_t */
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int32_t */
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int64_t */
+
+/* Define to the type of a signed integer type of width exactly 8 bits if such
+   a type exists and the standard includes do not define it. */
+/* #undef int8_t */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */
+ 
+/* once: _INCLUDE_NDN_IND_NDN_IND_CONFIG_H */
+#endif

--- a/VisualStudio/ndn-ind/ndn-ind.sln
+++ b/VisualStudio/ndn-ind/ndn-ind.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30709.132
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ndn-ind", "ndn-ind.vcxproj", "{B8004BD7-1372-4B5D-BF63-07696760C53B}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ndn-ind", "ndn-ind.vcxproj", "{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,19 +13,19 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x64.ActiveCfg = Debug|x64
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x64.Build.0 = Debug|x64
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x86.ActiveCfg = Debug|Win32
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x86.Build.0 = Debug|Win32
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x64.ActiveCfg = Release|x64
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x64.Build.0 = Release|x64
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x86.ActiveCfg = Release|Win32
-		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x86.Build.0 = Release|Win32
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Debug|x64.ActiveCfg = Debug|x64
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Debug|x64.Build.0 = Debug|x64
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Debug|x86.ActiveCfg = Debug|Win32
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Debug|x86.Build.0 = Debug|Win32
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Release|x64.ActiveCfg = Release|x64
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Release|x64.Build.0 = Release|x64
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Release|x86.ActiveCfg = Release|Win32
+		{5ADC4A32-007A-4F7B-A1FA-630CF3B3F060}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {75F5127D-DD64-43BD-97E3-C3AA3926BB0B}
+		SolutionGuid = {4232DDB4-339A-4F8A-A683-4610619CB325}
 	EndGlobalSection
 EndGlobal

--- a/VisualStudio/ndn-ind/ndn-ind.sln
+++ b/VisualStudio/ndn-ind/ndn-ind.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30709.132
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ndn-ind", "ndn-ind.vcxproj", "{B8004BD7-1372-4B5D-BF63-07696760C53B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x64.ActiveCfg = Debug|x64
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x64.Build.0 = Debug|x64
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x86.ActiveCfg = Debug|Win32
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Debug|x86.Build.0 = Debug|Win32
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x64.ActiveCfg = Release|x64
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x64.Build.0 = Release|x64
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x86.ActiveCfg = Release|Win32
+		{B8004BD7-1372-4B5D-BF63-07696760C53B}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {75F5127D-DD64-43BD-97E3-C3AA3926BB0B}
+	EndGlobalSection
+EndGlobal

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
-    <ProjectGuid>{b8004bd7-1372-4b5d-bf63-07696760c53b}</ProjectGuid>
+    <ProjectGuid>{5adc4a32-007a-4f7b-a1fa-630cf3b3f060}</ProjectGuid>
     <RootNamespace>ndnind</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -86,15 +86,15 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;NDNIND_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>
-      </SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -103,44 +103,33 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;NDNIND_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <CompileAsManaged>false</CompileAsManaged>
-      <AdditionalIncludeDirectories>..\..\..\vcpkg\installed\x64-windows\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <OmitDefaultLibName>true</OmitDefaultLibName>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>
-      </SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;NDN_IND_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>
-      </SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
-    <Lib>
-      <AdditionalDependencies>libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Lib>
-    <Lib>
-      <AdditionalLibraryDirectories>C:\Users\remap\Documents\GitHub\vcpkg\installed\x64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -148,32 +137,27 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;NDN_IND_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\..\vcpkg\installed\x64-windows\include;..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\vcpkg\installed\x64-windows\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAsManaged>false</CompileAsManaged>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <SubSystem>
-      </SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalLibraryDirectories>..\..\..\vcpkg\installed\x64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <Lib>
-      <AdditionalDependencies>libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Lib>
-    <Lib>
-      <AdditionalLibraryDirectories>C:\Users\remap\Documents\GitHub\vcpkg\installed\x64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\contrib\apache\apr_base64.h" />
     <ClInclude Include="..\..\contrib\murmur-hash\murmur-hash.h" />
-    <ClInclude Include="..\..\include\ndn-ind\ndn-ind-config.h" />
     <ClInclude Include="..\..\src\c\control-parameters.h" />
     <ClInclude Include="..\..\src\c\control-response.h" />
     <ClInclude Include="..\..\src\c\data.h" />
@@ -217,6 +201,7 @@
     <ClInclude Include="..\..\src\c\transport\socket-transport.h" />
     <ClInclude Include="..\..\src\c\transport\tcp-transport.h" />
     <ClInclude Include="..\..\src\c\transport\udp-transport.h" />
+    <ClInclude Include="..\..\src\c\transport\unix-transport.h" />
     <ClInclude Include="..\..\src\c\util\blob.h" />
     <ClInclude Include="..\..\src\c\util\crypto.h" />
     <ClInclude Include="..\..\src\c\util\dynamic-uint8-array.h" />
@@ -227,7 +212,6 @@
     <ClInclude Include="..\..\src\encoding\der\der-exception.hpp" />
     <ClInclude Include="..\..\src\encoding\der\der-node-type.hpp" />
     <ClInclude Include="..\..\src\encoding\der\der-node.hpp" />
-    <ClInclude Include="..\..\src\encoding\element-listener.hpp" />
     <ClInclude Include="..\..\src\encoding\tlv-decoder.hpp" />
     <ClInclude Include="..\..\src\encoding\tlv-encoder.hpp" />
     <ClInclude Include="..\..\src\impl\delayed-call-table.hpp" />
@@ -245,6 +229,7 @@
     <ClInclude Include="..\..\src\sync\detail\psync-state.hpp" />
     <ClInclude Include="..\..\src\sync\detail\psync-user-prefixes.hpp" />
     <ClInclude Include="..\..\src\sync\digest-tree.hpp" />
+    <ClInclude Include="..\..\src\transport\async-socket-transport.hpp" />
     <ClInclude Include="..\..\src\util\boost-info-parser.hpp" />
     <ClInclude Include="..\..\src\util\command-interest-generator.hpp" />
     <ClInclude Include="..\..\src\util\config-file.hpp" />
@@ -259,6 +244,8 @@
     <ClInclude Include="..\..\src\util\regex\ndn-regex-repeat-matcher.hpp" />
     <ClInclude Include="..\..\src\util\regex\ndn-regex-top-matcher.hpp" />
     <ClInclude Include="..\..\src\util\sqlite3-statement.hpp" />
+    <ClInclude Include="framework.h" />
+    <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\contrib\apache\apr_base64.c" />
@@ -366,6 +353,7 @@
     <ClCompile Include="..\..\src\lite\signature-lite.cpp" />
     <ClCompile Include="..\..\src\lite\transport\tcp-transport-lite.cpp" />
     <ClCompile Include="..\..\src\lite\transport\udp-transport-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\transport\unix-transport-lite.cpp" />
     <ClCompile Include="..\..\src\lite\util\blob-lite.cpp" />
     <ClCompile Include="..\..\src\lite\util\crypto-lite.cpp" />
     <ClCompile Include="..\..\src\lite\util\dynamic-malloc-uint8-array-lite.cpp" />
@@ -444,9 +432,12 @@
     <ClCompile Include="..\..\src\sync\full-psync2017.cpp" />
     <ClCompile Include="..\..\src\sync\psync-producer-base.cpp" />
     <ClCompile Include="..\..\src\threadsafe-face.cpp" />
+    <ClCompile Include="..\..\src\transport\async-tcp-transport.cpp" />
+    <ClCompile Include="..\..\src\transport\async-unix-transport.cpp" />
     <ClCompile Include="..\..\src\transport\tcp-transport.cpp" />
     <ClCompile Include="..\..\src\transport\transport.cpp" />
     <ClCompile Include="..\..\src\transport\udp-transport.cpp" />
+    <ClCompile Include="..\..\src\transport\unix-transport.cpp" />
     <ClCompile Include="..\..\src\util\boost-info-parser.cpp" />
     <ClCompile Include="..\..\src\util\command-interest-generator.cpp" />
     <ClCompile Include="..\..\src\util\config-file.cpp" />

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj
@@ -1,0 +1,472 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{b8004bd7-1372-4b5d-bf63-07696760c53b}</ProjectGuid>
+    <RootNamespace>ndnind</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <CompileAsManaged>false</CompileAsManaged>
+      <AdditionalIncludeDirectories>..\..\..\vcpkg\installed\x64-windows\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <OmitDefaultLibName>true</OmitDefaultLibName>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\Users\remap\Documents\GitHub\vcpkg\installed\x64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\..\vcpkg\installed\x64-windows\include;..\..\include</AdditionalIncludeDirectories>
+      <CompileAsManaged>false</CompileAsManaged>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\Users\remap\Documents\GitHub\vcpkg\installed\x64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\contrib\apache\apr_base64.h" />
+    <ClInclude Include="..\..\contrib\murmur-hash\murmur-hash.h" />
+    <ClInclude Include="..\..\include\ndn-ind\ndn-ind-config.h" />
+    <ClInclude Include="..\..\src\c\control-parameters.h" />
+    <ClInclude Include="..\..\src\c\control-response.h" />
+    <ClInclude Include="..\..\src\c\data.h" />
+    <ClInclude Include="..\..\src\c\delegation-set.h" />
+    <ClInclude Include="..\..\src\c\encoding\element-listener.h" />
+    <ClInclude Include="..\..\src\c\encoding\element-reader.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_2-wire-format.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_3-wire-format.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-control-parameters.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-control-response.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-data.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-decoder.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-delegation-set.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-encoder.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-encrypted-content.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-interest.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-key-locator.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-lp-packet.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-name.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-signature-info.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.h" />
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv.h" />
+    <ClInclude Include="..\..\src\c\encrypt\algo\aes-algorithm.h" />
+    <ClInclude Include="..\..\src\c\encrypt\algo\chacha20-algorithm.h" />
+    <ClInclude Include="..\..\src\c\encrypt\algo\des-algorithm.h" />
+    <ClInclude Include="..\..\src\c\encrypt\encrypted-content.h" />
+    <ClInclude Include="..\..\src\c\forwarding-flags-impl.h" />
+    <ClInclude Include="..\..\src\c\interest.h" />
+    <ClInclude Include="..\..\src\c\key-locator.h" />
+    <ClInclude Include="..\..\src\c\lp\congestion-mark.h" />
+    <ClInclude Include="..\..\src\c\lp\incoming-face-id.h" />
+    <ClInclude Include="..\..\src\c\lp\lp-packet.h" />
+    <ClInclude Include="..\..\src\c\name.h" />
+    <ClInclude Include="..\..\src\c\network-nack.h" />
+    <ClInclude Include="..\..\src\c\registration-options.h" />
+    <ClInclude Include="..\..\src\c\security\ec-private-key.h" />
+    <ClInclude Include="..\..\src\c\security\ec-public-key.h" />
+    <ClInclude Include="..\..\src\c\security\rsa-private-key.h" />
+    <ClInclude Include="..\..\src\c\security\rsa-public-key.h" />
+    <ClInclude Include="..\..\src\c\security\validity-period.h" />
+    <ClInclude Include="..\..\src\c\transport\socket-transport.h" />
+    <ClInclude Include="..\..\src\c\transport\tcp-transport.h" />
+    <ClInclude Include="..\..\src\c\transport\udp-transport.h" />
+    <ClInclude Include="..\..\src\c\util\blob.h" />
+    <ClInclude Include="..\..\src\c\util\crypto.h" />
+    <ClInclude Include="..\..\src\c\util\dynamic-uint8-array.h" />
+    <ClInclude Include="..\..\src\c\util\endian.h" />
+    <ClInclude Include="..\..\src\c\util\ndn_memory.h" />
+    <ClInclude Include="..\..\src\c\util\ndn_realloc.h" />
+    <ClInclude Include="..\..\src\c\util\time.h" />
+    <ClInclude Include="..\..\src\encoding\der\der-exception.hpp" />
+    <ClInclude Include="..\..\src\encoding\der\der-node-type.hpp" />
+    <ClInclude Include="..\..\src\encoding\der\der-node.hpp" />
+    <ClInclude Include="..\..\src\encoding\element-listener.hpp" />
+    <ClInclude Include="..\..\src\encoding\tlv-decoder.hpp" />
+    <ClInclude Include="..\..\src\encoding\tlv-encoder.hpp" />
+    <ClInclude Include="..\..\src\impl\delayed-call-table.hpp" />
+    <ClInclude Include="..\..\src\impl\interest-filter-table.hpp" />
+    <ClInclude Include="..\..\src\impl\pending-interest-table.hpp" />
+    <ClInclude Include="..\..\src\impl\registered-prefix-table.hpp" />
+    <ClInclude Include="..\..\src\lp\congestion-mark.hpp" />
+    <ClInclude Include="..\..\src\lp\incoming-face-id.hpp" />
+    <ClInclude Include="..\..\src\lp\lp-packet.hpp" />
+    <ClInclude Include="..\..\src\node.hpp" />
+    <ClInclude Include="..\..\src\security\pib\detail\pib-identity-impl.hpp" />
+    <ClInclude Include="..\..\src\security\pib\detail\pib-key-impl.hpp" />
+    <ClInclude Include="..\..\src\sync\detail\invertible-bloom-lookup-table.hpp" />
+    <ClInclude Include="..\..\src\sync\detail\psync-segment-publisher.hpp" />
+    <ClInclude Include="..\..\src\sync\detail\psync-state.hpp" />
+    <ClInclude Include="..\..\src\sync\detail\psync-user-prefixes.hpp" />
+    <ClInclude Include="..\..\src\sync\digest-tree.hpp" />
+    <ClInclude Include="..\..\src\util\boost-info-parser.hpp" />
+    <ClInclude Include="..\..\src\util\command-interest-generator.hpp" />
+    <ClInclude Include="..\..\src\util\config-file.hpp" />
+    <ClInclude Include="..\..\src\util\dynamic-uint8-vector.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-backref-manager.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-backref-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-component-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-component-set-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-matcher-base.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-repeat-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-top-matcher.hpp" />
+    <ClInclude Include="..\..\src\util\sqlite3-statement.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\contrib\apache\apr_base64.c" />
+    <ClCompile Include="..\..\contrib\murmur-hash\murmur-hash.c" />
+    <ClCompile Include="..\..\src\common.cpp" />
+    <ClCompile Include="..\..\src\control-parameters.cpp" />
+    <ClCompile Include="..\..\src\control-response.cpp" />
+    <ClCompile Include="..\..\src\c\control-parameters_c.c" />
+    <ClCompile Include="..\..\src\c\encoding\element-reader.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_2-wire-format_c.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_3-wire-format_c.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-control-parameters.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-control-response.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-data.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-decoder.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-delegation-set.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-encoder.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-encrypted-content.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-interest.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-key-locator.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-lp-packet.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-name.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-signature-info.c" />
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.c" />
+    <ClCompile Include="..\..\src\c\encrypt\algo\aes-algorithm_c.c" />
+    <ClCompile Include="..\..\src\c\encrypt\algo\chacha20-algorithm_c.c" />
+    <ClCompile Include="..\..\src\c\encrypt\algo\des-algorithm_c.c" />
+    <ClCompile Include="..\..\src\c\errors.c" />
+    <ClCompile Include="..\..\src\c\interest_c.c" />
+    <ClCompile Include="..\..\src\c\lp\congestion-mark_c.c" />
+    <ClCompile Include="..\..\src\c\lp\incoming-face-id_c.c" />
+    <ClCompile Include="..\..\src\c\name_c.c" />
+    <ClCompile Include="..\..\src\c\network-nack_c.c" />
+    <ClCompile Include="..\..\src\c\registration-options.c" />
+    <ClCompile Include="..\..\src\c\security\ec-private-key.c" />
+    <ClCompile Include="..\..\src\c\security\ec-public-key.c" />
+    <ClCompile Include="..\..\src\c\security\rsa-private-key.c" />
+    <ClCompile Include="..\..\src\c\security\rsa-public-key.c" />
+    <ClCompile Include="..\..\src\c\transport\socket-transport.c" />
+    <ClCompile Include="..\..\src\c\transport\tcp-transport_c.c" />
+    <ClCompile Include="..\..\src\c\util\blob_c.c" />
+    <ClCompile Include="..\..\src\c\util\crypto.c" />
+    <ClCompile Include="..\..\src\c\util\dynamic-uint8-array.c" />
+    <ClCompile Include="..\..\src\c\util\ndn_memory.c" />
+    <ClCompile Include="..\..\src\c\util\ndn_realloc.c" />
+    <ClCompile Include="..\..\src\c\util\time.c" />
+    <ClCompile Include="..\..\src\data.cpp" />
+    <ClCompile Include="..\..\src\delegation-set.cpp" />
+    <ClCompile Include="..\..\src\digest-sha256-signature.cpp" />
+    <ClCompile Include="..\..\src\encoding\base64.cpp" />
+    <ClCompile Include="..\..\src\encoding\der\der-exception.cpp" />
+    <ClCompile Include="..\..\src\encoding\der\der-node.cpp" />
+    <ClCompile Include="..\..\src\encoding\element-listener.cpp" />
+    <ClCompile Include="..\..\src\encoding\oid.cpp" />
+    <ClCompile Include="..\..\src\encoding\protobuf-tlv.cpp" />
+    <ClCompile Include="..\..\src\encoding\tlv-0_1-wire-format.cpp" />
+    <ClCompile Include="..\..\src\encoding\tlv-0_1_1-wire-format.cpp" />
+    <ClCompile Include="..\..\src\encoding\tlv-0_2-wire-format.cpp" />
+    <ClCompile Include="..\..\src\encoding\tlv-0_3-wire-format.cpp" />
+    <ClCompile Include="..\..\src\encoding\tlv-wire-format.cpp" />
+    <ClCompile Include="..\..\src\encoding\wire-format.cpp" />
+    <ClCompile Include="..\..\src\encrypt\access-manager-v2.cpp" />
+    <ClCompile Include="..\..\src\encrypt\decryptor-v2.cpp" />
+    <ClCompile Include="..\..\src\encrypt\encrypted-content.cpp" />
+    <ClCompile Include="..\..\src\encrypt\encryptor-v2.cpp" />
+    <ClCompile Include="..\..\src\exclude.cpp" />
+    <ClCompile Include="..\..\src\face.cpp" />
+    <ClCompile Include="..\..\src\generic-signature.cpp" />
+    <ClCompile Include="..\..\src\hmac-with-sha256-signature.cpp" />
+    <ClCompile Include="..\..\src\impl\delayed-call-table.cpp" />
+    <ClCompile Include="..\..\src\impl\interest-filter-table.cpp" />
+    <ClCompile Include="..\..\src\impl\pending-interest-table.cpp" />
+    <ClCompile Include="..\..\src\impl\registered-prefix-table.cpp" />
+    <ClCompile Include="..\..\src\in-memory-storage\in-memory-storage-retaining.cpp" />
+    <ClCompile Include="..\..\src\interest-filter.cpp" />
+    <ClCompile Include="..\..\src\interest.cpp" />
+    <ClCompile Include="..\..\src\key-locator.cpp" />
+    <ClCompile Include="..\..\src\link.cpp" />
+    <ClCompile Include="..\..\src\lite\control-parameters-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\control-response-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\data-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\delegation-set-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encoding\element-listener-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_2-wire-format-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_3-wire-format-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encrypt\algo\aes-algorithm-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encrypt\algo\chacha20-algorithm-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encrypt\algo\des-algorithm-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encrypt\encrypted-content-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\exclude-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\interest-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\key-locator-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\lp\congestion-mark-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\lp\incoming-face-id-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\lp\lp-packet-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\meta-info-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\name-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\network-nack-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\registration-options-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\security\ec-private-key-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\security\ec-public-key-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\security\rsa-private-key-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\security\rsa-public-key-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\security\validity-period-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\signature-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\transport\tcp-transport-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\transport\udp-transport-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\util\blob-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\util\crypto-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\util\dynamic-malloc-uint8-array-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\util\dynamic-uint8-array-lite.cpp" />
+    <ClCompile Include="..\..\src\lp\congestion-mark.cpp" />
+    <ClCompile Include="..\..\src\lp\incoming-face-id.cpp" />
+    <ClCompile Include="..\..\src\lp\lp-packet.cpp" />
+    <ClCompile Include="..\..\src\meta-info.cpp" />
+    <ClCompile Include="..\..\src\name.cpp" />
+    <ClCompile Include="..\..\src\network-nack.cpp" />
+    <ClCompile Include="..\..\src\node.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\certificate-extension.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\certificate-subject-description.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\certificate.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\public-key.cpp" />
+    <ClCompile Include="..\..\src\security\command-interest-preparer.cpp" />
+    <ClCompile Include="..\..\src\security\command-interest-signer.cpp" />
+    <ClCompile Include="..\..\src\security\key-chain.cpp" />
+    <ClCompile Include="..\..\src\security\key-params.cpp" />
+    <ClCompile Include="..\..\src\security\pib\detail\pib-identity-impl.cpp" />
+    <ClCompile Include="..\..\src\security\pib\detail\pib-key-impl.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-certificate-container.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-identity-container.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-identity.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-key-container.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-key.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-memory.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib-sqlite3.cpp" />
+    <ClCompile Include="..\..\src\security\pib\pib.cpp" />
+    <ClCompile Include="..\..\src\security\safe-bag.cpp" />
+    <ClCompile Include="..\..\src\security\security-exception.cpp" />
+    <ClCompile Include="..\..\src\security\signing-info.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-file.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-memory.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-osx.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-memory.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-osx.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm-private-key.cpp" />
+    <ClCompile Include="..\..\src\security\tpm\tpm.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-cache-v2.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-from-network.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-offline.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-storage.cpp" />
+    <ClCompile Include="..\..\src\security\v2\certificate-v2.cpp" />
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-container.cpp" />
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-group.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-error.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy-accept-all.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy-command-interest.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy-config.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy-from-pib.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy-simple-hierarchy.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-policy.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validation-state.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-checker.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-filter.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-name-relation.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-rule.cpp" />
+    <ClCompile Include="..\..\src\security\v2\validator.cpp" />
+    <ClCompile Include="..\..\src\security\validator-null.cpp" />
+    <ClCompile Include="..\..\src\security\validity-period.cpp" />
+    <ClCompile Include="..\..\src\security\verification-helpers.cpp" />
+    <ClCompile Include="..\..\src\sha256-with-ecdsa-signature.cpp" />
+    <ClCompile Include="..\..\src\sha256-with-rsa-signature.cpp" />
+    <ClCompile Include="..\..\src\signature.cpp" />
+    <ClCompile Include="..\..\src\sync\chrono-sync2013.cpp" />
+    <ClCompile Include="..\..\src\sync\detail\invertible-bloom-lookup-table.cpp" />
+    <ClCompile Include="..\..\src\sync\detail\psync-segment-publisher.cpp" />
+    <ClCompile Include="..\..\src\sync\detail\psync-state.cpp" />
+    <ClCompile Include="..\..\src\sync\detail\psync-user-prefixes.cpp" />
+    <ClCompile Include="..\..\src\sync\digest-tree.cpp" />
+    <ClCompile Include="..\..\src\sync\full-psync2017-with-users.cpp" />
+    <ClCompile Include="..\..\src\sync\full-psync2017.cpp" />
+    <ClCompile Include="..\..\src\sync\psync-producer-base.cpp" />
+    <ClCompile Include="..\..\src\threadsafe-face.cpp" />
+    <ClCompile Include="..\..\src\transport\tcp-transport.cpp" />
+    <ClCompile Include="..\..\src\transport\transport.cpp" />
+    <ClCompile Include="..\..\src\transport\udp-transport.cpp" />
+    <ClCompile Include="..\..\src\util\boost-info-parser.cpp" />
+    <ClCompile Include="..\..\src\util\command-interest-generator.cpp" />
+    <ClCompile Include="..\..\src\util\config-file.cpp" />
+    <ClCompile Include="..\..\src\util\dynamic-uint8-vector.cpp" />
+    <ClCompile Include="..\..\src\util\exponential-re-express.cpp" />
+    <ClCompile Include="..\..\src\util\logging.cpp" />
+    <ClCompile Include="..\..\src\util\memory-content-cache.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-manager.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-set-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-matcher-base.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-repeat-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-top-matcher.cpp" />
+    <ClCompile Include="..\..\src\util\segment-fetcher.cpp" />
+    <ClCompile Include="..\..\src\util\sqlite3-statement.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
@@ -1,0 +1,1014 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{6c42ab3c-b3bf-4cd6-afc8-de5c15522060}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c">
+      <UniqueIdentifier>{cc56df66-7170-436c-bf3a-cc498e09bc3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\encoding">
+      <UniqueIdentifier>{c615d1f8-4320-4a69-904f-2a361124ce54}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\encrypt">
+      <UniqueIdentifier>{c1d0ddda-f5fb-4b87-836c-5a6854033497}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\lp">
+      <UniqueIdentifier>{ccfba7bf-719e-46a6-b87f-7c1921a35178}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\encoding\tlv">
+      <UniqueIdentifier>{68b7281e-6fd0-4e22-b11b-ba39da1e742e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\encrypt\algo">
+      <UniqueIdentifier>{fa6c7267-62dd-4b04-9de9-05a796234817}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\security">
+      <UniqueIdentifier>{7ad190ae-3fba-4e11-a478-10dfd00fe250}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\util">
+      <UniqueIdentifier>{63396249-66f5-4309-8dde-9187d9cb8b57}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\contrib">
+      <UniqueIdentifier>{5bfb57ca-1974-40fa-8453-09e56656ba7f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\contrib\apache">
+      <UniqueIdentifier>{161699a0-0465-4ea5-9846-a8ec4779dbde}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\contrib\murmur-hash">
+      <UniqueIdentifier>{52059f3b-10dd-4544-8f4c-f9777d879f4f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encoding">
+      <UniqueIdentifier>{1adbd918-5c8c-4394-bffc-7bc739b0fc58}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encoding\der">
+      <UniqueIdentifier>{c68b954f-3839-48f3-9ed2-88697c7e0a7c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encrypt">
+      <UniqueIdentifier>{4548cf16-d179-442f-8980-88130c94c217}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\impl">
+      <UniqueIdentifier>{cb8fdb0f-a4d0-4f47-a8f8-daea746383ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\in-memory-storage">
+      <UniqueIdentifier>{48c09630-2b36-415e-a1f5-194bb3833314}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite">
+      <UniqueIdentifier>{926b3a96-7a5c-4ce5-abf8-b5ecd1961dad}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encoding">
+      <UniqueIdentifier>{42e1c8b8-df3f-4e8c-a885-b73d90d1d03b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encrypt">
+      <UniqueIdentifier>{a0236eff-8602-475b-a3d5-0e5b82a5d9eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\lp">
+      <UniqueIdentifier>{08b1f613-c762-4fe3-a8f8-1efd543be195}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encrypt\algo">
+      <UniqueIdentifier>{77c20b8b-0f35-4f0f-9b2b-6411704f4305}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\security">
+      <UniqueIdentifier>{d78f8f50-9272-4b75-afaa-32a834ec6fc4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\util">
+      <UniqueIdentifier>{a917de6e-1f99-495b-9fb3-f99d18e6f441}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lp">
+      <UniqueIdentifier>{2ad9739c-122e-4fa7-bd13-b69f92bd7a8a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security">
+      <UniqueIdentifier>{36b92e43-d572-43d4-b60f-2c4439d8eb58}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\certificate">
+      <UniqueIdentifier>{ac7cb166-d0e9-4e36-809a-4950852a35a1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\pib">
+      <UniqueIdentifier>{dbbf0971-cfbf-49a1-bf8f-237036530469}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\tpm">
+      <UniqueIdentifier>{2336e7ea-be73-43f2-9dd8-dc3fa3b2ab86}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\v2">
+      <UniqueIdentifier>{8a700c65-8076-4597-af6c-ea7a5b40b1dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\pib\detail">
+      <UniqueIdentifier>{ab0a5b2f-e3eb-4bcf-a115-cc44008a41cf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\v2\validator-config">
+      <UniqueIdentifier>{eced8c0c-082a-4963-857c-2b9b3b29d1f8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sync">
+      <UniqueIdentifier>{5475f154-30e2-4e82-ace6-453107db3b47}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sync\detail">
+      <UniqueIdentifier>{63b4eb08-25f1-4c0a-adbf-f40acc2f42c8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\util">
+      <UniqueIdentifier>{1e22f8e0-f0e4-4e99-8f73-cd8d15ec9a0a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\util\regex">
+      <UniqueIdentifier>{80d83e0b-7d56-4e02-8435-476e780bbd72}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\c\transport">
+      <UniqueIdentifier>{4d4c9e33-f8f3-4fb3-88aa-d0f016573430}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\transport">
+      <UniqueIdentifier>{cdf10735-994b-4e62-9d4c-c6be508eac5d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\transport">
+      <UniqueIdentifier>{ad5dbc89-5aeb-46b8-b476-40c0372f42a4}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\c\control-parameters.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\control-response.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\data.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\delegation-set.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\forwarding-flags-impl.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\interest.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\key-locator.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\name.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\network-nack.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\registration-options.h">
+      <Filter>Source Files\src\c</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\element-listener.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\element-reader.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_2-wire-format.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_3-wire-format.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-control-parameters.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-control-response.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-data.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-decoder.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-delegation-set.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-encoder.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-encrypted-content.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-interest.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-key-locator.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-lp-packet.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-name.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-signature-info.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.h">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encrypt\encrypted-content.h">
+      <Filter>Source Files\src\c\encrypt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encrypt\algo\aes-algorithm.h">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encrypt\algo\chacha20-algorithm.h">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encrypt\algo\des-algorithm.h">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\lp\congestion-mark.h">
+      <Filter>Source Files\src\c\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\lp\incoming-face-id.h">
+      <Filter>Source Files\src\c\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\lp\lp-packet.h">
+      <Filter>Source Files\src\c\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\blob.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\crypto.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\dynamic-uint8-array.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\endian.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\ndn_memory.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\ndn_realloc.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\util\time.h">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\ec-private-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\ec-public-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\rsa-private-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\rsa-public-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\validity-period.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\contrib\apache\apr_base64.h">
+      <Filter>Source Files\contrib\apache</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\contrib\murmur-hash\murmur-hash.h">
+      <Filter>Source Files\contrib\murmur-hash</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\element-listener.hpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\tlv-decoder.hpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\tlv-encoder.hpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\der\der-exception.hpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\der\der-node.hpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\der\der-node-type.hpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\impl\delayed-call-table.hpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\impl\interest-filter-table.hpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\impl\pending-interest-table.hpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\impl\registered-prefix-table.hpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\node.hpp">
+      <Filter>Source Files\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lp\congestion-mark.hpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lp\incoming-face-id.hpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lp\lp-packet.hpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\security\pib\detail\pib-identity-impl.hpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\security\pib\detail\pib-key-impl.hpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sync\digest-tree.hpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sync\detail\invertible-bloom-lookup-table.hpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sync\detail\psync-segment-publisher.hpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sync\detail\psync-state.hpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\sync\detail\psync-user-prefixes.hpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\boost-info-parser.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\command-interest-generator.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\config-file.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\dynamic-uint8-vector.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\sqlite3-statement.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-backref-manager.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-backref-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-component-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-component-set-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-matcher-base.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-repeat-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\regex\ndn-regex-top-matcher.hpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\ndn-ind\ndn-ind-config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\socket-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\tcp-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\udp-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\c\control-parameters_c.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\errors.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\interest_c.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\name_c.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\network-nack_c.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\registration-options.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\element-reader.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_2-wire-format_c.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_3-wire-format_c.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-control-parameters.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-control-response.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-data.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-decoder.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-delegation-set.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-encoder.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-encrypted-content.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-interest.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-key-locator.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-lp-packet.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-name.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-signature-info.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.c">
+      <Filter>Source Files\src\c\encoding\tlv</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encrypt\algo\aes-algorithm_c.c">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encrypt\algo\chacha20-algorithm_c.c">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encrypt\algo\des-algorithm_c.c">
+      <Filter>Source Files\src\c\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\lp\congestion-mark_c.c">
+      <Filter>Source Files\src\c\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\lp\incoming-face-id_c.c">
+      <Filter>Source Files\src\c\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\blob_c.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\crypto.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\dynamic-uint8-array.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\ndn_memory.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\ndn_realloc.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\util\time.c">
+      <Filter>Source Files\src\c\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\ec-private-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\ec-public-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\rsa-private-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\rsa-public-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\contrib\murmur-hash\murmur-hash.c">
+      <Filter>Source Files\contrib\murmur-hash</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\contrib\apache\apr_base64.c">
+      <Filter>Source Files\contrib\apache</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\base64.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\element-listener.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\oid.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\protobuf-tlv.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\tlv-0_1_1-wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\tlv-0_1-wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\tlv-0_2-wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\tlv-0_3-wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\tlv-wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\wire-format.cpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\der\der-exception.cpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\der\der-node.cpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\impl\delayed-call-table.cpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\impl\interest-filter-table.cpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\impl\pending-interest-table.cpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\impl\registered-prefix-table.cpp">
+      <Filter>Source Files\src\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\access-manager-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\decryptor-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\encrypted-content.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\encryptor-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\common.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\control-parameters.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\control-response.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\data.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\delegation-set.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\digest-sha256-signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\exclude.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\face.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\generic-signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\hmac-with-sha256-signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interest.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interest-filter.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\key-locator.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\link.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\meta-info.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\name.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\network-nack.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\node.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sha256-with-ecdsa-signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sha256-with-rsa-signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\signature.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\threadsafe-face.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\in-memory-storage\in-memory-storage-retaining.cpp">
+      <Filter>Source Files\src\in-memory-storage</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\element-listener-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_2-wire-format-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_3-wire-format-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\encrypted-content-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\aes-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\chacha20-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\des-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\congestion-mark-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\incoming-face-id-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\lp-packet-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\blob-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\crypto-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\dynamic-malloc-uint8-array-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\dynamic-uint8-array-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\ec-private-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\ec-public-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\rsa-private-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\rsa-public-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\validity-period-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\control-parameters-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\control-response-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\data-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\delegation-set-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\exclude-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\interest-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\key-locator-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\meta-info-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\name-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\network-nack-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\registration-options-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\signature-lite.cpp">
+      <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lp\congestion-mark.cpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lp\incoming-face-id.cpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lp\lp-packet.cpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate-extension.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate-subject-description.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\public-key.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-certificate-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-identity.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-identity-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-key.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-key-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-memory.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-sqlite3.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\detail\pib-identity-impl.cpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\detail\pib-key-impl.cpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-cache-v2.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-from-network.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-offline.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-storage.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-v2.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-container.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-group.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-error.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-accept-all.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-command-interest.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-config.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-from-pib.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-simple-hierarchy.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-state.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-checker.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-filter.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-name-relation.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-rule.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-file.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-memory.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-osx.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-memory.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-osx.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-private-key.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\chrono-sync2013.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\digest-tree.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\full-psync2017.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\full-psync2017-with-users.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\psync-producer-base.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\invertible-bloom-lookup-table.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-segment-publisher.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-state.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-user-prefixes.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\boost-info-parser.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\command-interest-generator.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\config-file.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\dynamic-uint8-vector.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\exponential-re-express.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\logging.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\memory-content-cache.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\segment-fetcher.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\sqlite3-statement.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-manager.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-set-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-matcher-base.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-repeat-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-top-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\command-interest-preparer.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\command-interest-signer.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\key-chain.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\key-params.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\safe-bag.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\security-exception.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\signing-info.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\validator-null.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\validity-period.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\verification-helpers.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\transport\socket-transport.c">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\transport\tcp-transport_c.c">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\tcp-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\udp-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\transport\tcp-transport-lite.cpp">
+      <Filter>Source Files\src\lite\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\transport\udp-transport-lite.cpp">
+      <Filter>Source Files\src\lite\transport</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
@@ -13,166 +13,136 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Source Files\src">
-      <UniqueIdentifier>{6c42ab3c-b3bf-4cd6-afc8-de5c15522060}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c">
-      <UniqueIdentifier>{cc56df66-7170-436c-bf3a-cc498e09bc3e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\encoding">
-      <UniqueIdentifier>{c615d1f8-4320-4a69-904f-2a361124ce54}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\encrypt">
-      <UniqueIdentifier>{c1d0ddda-f5fb-4b87-836c-5a6854033497}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\lp">
-      <UniqueIdentifier>{ccfba7bf-719e-46a6-b87f-7c1921a35178}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\encoding\tlv">
-      <UniqueIdentifier>{68b7281e-6fd0-4e22-b11b-ba39da1e742e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\encrypt\algo">
-      <UniqueIdentifier>{fa6c7267-62dd-4b04-9de9-05a796234817}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\security">
-      <UniqueIdentifier>{7ad190ae-3fba-4e11-a478-10dfd00fe250}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\c\util">
-      <UniqueIdentifier>{63396249-66f5-4309-8dde-9187d9cb8b57}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\contrib">
-      <UniqueIdentifier>{5bfb57ca-1974-40fa-8453-09e56656ba7f}</UniqueIdentifier>
+      <UniqueIdentifier>{0bb3fe09-6d1f-42fe-a941-823d74c94c54}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source Files\contrib\apache">
-      <UniqueIdentifier>{161699a0-0465-4ea5-9846-a8ec4779dbde}</UniqueIdentifier>
+      <UniqueIdentifier>{e2736d3f-4deb-4be3-904a-2862fba2cbdc}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source Files\contrib\murmur-hash">
-      <UniqueIdentifier>{52059f3b-10dd-4544-8f4c-f9777d879f4f}</UniqueIdentifier>
+      <UniqueIdentifier>{07ea5c3a-68da-43a1-bf4d-6d03a0bd3b61}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\encoding">
-      <UniqueIdentifier>{1adbd918-5c8c-4394-bffc-7bc739b0fc58}</UniqueIdentifier>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{32b25775-f44d-461c-ba6b-c4498bc58c58}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\encoding\der">
-      <UniqueIdentifier>{c68b954f-3839-48f3-9ed2-88697c7e0a7c}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c">
+      <UniqueIdentifier>{c1960f75-602d-43db-8d30-3dcc58fe5365}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\encrypt">
-      <UniqueIdentifier>{4548cf16-d179-442f-8980-88130c94c217}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\encoding">
+      <UniqueIdentifier>{c851a024-58cd-4766-82f9-c27364791864}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\impl">
-      <UniqueIdentifier>{cb8fdb0f-a4d0-4f47-a8f8-daea746383ce}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\encoding\tlv">
+      <UniqueIdentifier>{132fd72d-aaf4-488c-83a3-44649ceaa56f}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\in-memory-storage">
-      <UniqueIdentifier>{48c09630-2b36-415e-a1f5-194bb3833314}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\encrypt">
+      <UniqueIdentifier>{7ca9ab5e-73dc-44be-b55d-fd8740ca5e45}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\lite">
-      <UniqueIdentifier>{926b3a96-7a5c-4ce5-abf8-b5ecd1961dad}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\encrypt\algo">
+      <UniqueIdentifier>{b9ec16ba-3a60-4043-a84e-d39cc678b7f3}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\lite\encoding">
-      <UniqueIdentifier>{42e1c8b8-df3f-4e8c-a885-b73d90d1d03b}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\lp">
+      <UniqueIdentifier>{72fc8bae-5042-4cf2-b00c-abdfb23dfc93}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\lite\encrypt">
-      <UniqueIdentifier>{a0236eff-8602-475b-a3d5-0e5b82a5d9eb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\lite\lp">
-      <UniqueIdentifier>{08b1f613-c762-4fe3-a8f8-1efd543be195}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\lite\encrypt\algo">
-      <UniqueIdentifier>{77c20b8b-0f35-4f0f-9b2b-6411704f4305}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\lite\security">
-      <UniqueIdentifier>{d78f8f50-9272-4b75-afaa-32a834ec6fc4}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\lite\util">
-      <UniqueIdentifier>{a917de6e-1f99-495b-9fb3-f99d18e6f441}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\lp">
-      <UniqueIdentifier>{2ad9739c-122e-4fa7-bd13-b69f92bd7a8a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security">
-      <UniqueIdentifier>{36b92e43-d572-43d4-b60f-2c4439d8eb58}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\certificate">
-      <UniqueIdentifier>{ac7cb166-d0e9-4e36-809a-4950852a35a1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\pib">
-      <UniqueIdentifier>{dbbf0971-cfbf-49a1-bf8f-237036530469}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\tpm">
-      <UniqueIdentifier>{2336e7ea-be73-43f2-9dd8-dc3fa3b2ab86}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\v2">
-      <UniqueIdentifier>{8a700c65-8076-4597-af6c-ea7a5b40b1dd}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\pib\detail">
-      <UniqueIdentifier>{ab0a5b2f-e3eb-4bcf-a115-cc44008a41cf}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\security\v2\validator-config">
-      <UniqueIdentifier>{eced8c0c-082a-4963-857c-2b9b3b29d1f8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\sync">
-      <UniqueIdentifier>{5475f154-30e2-4e82-ace6-453107db3b47}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\sync\detail">
-      <UniqueIdentifier>{63b4eb08-25f1-4c0a-adbf-f40acc2f42c8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\util">
-      <UniqueIdentifier>{1e22f8e0-f0e4-4e99-8f73-cd8d15ec9a0a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\src\util\regex">
-      <UniqueIdentifier>{80d83e0b-7d56-4e02-8435-476e780bbd72}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\security">
+      <UniqueIdentifier>{882a6647-4bde-4eb6-b109-504ed407ba2f}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source Files\src\c\transport">
-      <UniqueIdentifier>{4d4c9e33-f8f3-4fb3-88aa-d0f016573430}</UniqueIdentifier>
+      <UniqueIdentifier>{ec3f0106-1436-4cab-9eb6-722e0b3b8720}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\transport">
-      <UniqueIdentifier>{cdf10735-994b-4e62-9d4c-c6be508eac5d}</UniqueIdentifier>
+    <Filter Include="Source Files\src\c\util">
+      <UniqueIdentifier>{2718d00f-d550-4c44-b0d3-72516498ab4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite">
+      <UniqueIdentifier>{2c711bb4-a60a-4ab1-893a-be5b7e603505}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encoding">
+      <UniqueIdentifier>{44aeeb63-ad07-4d7f-943c-1361042d7213}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encrypt">
+      <UniqueIdentifier>{d23ab940-0391-4193-aeb0-6270281d0f5a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\encrypt\algo">
+      <UniqueIdentifier>{fb86ce3b-7728-42dc-aa4e-1f38e2869775}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\lp">
+      <UniqueIdentifier>{b9bed530-8575-45bb-9c29-3235595721e8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\security">
+      <UniqueIdentifier>{6793c0e5-7c8d-40b9-ba7f-3ab495b54057}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source Files\src\lite\transport">
-      <UniqueIdentifier>{ad5dbc89-5aeb-46b8-b476-40c0372f42a4}</UniqueIdentifier>
+      <UniqueIdentifier>{91423f8d-db80-439d-a2e1-7176ae6403b6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lite\util">
+      <UniqueIdentifier>{75dc3b3a-7da6-415a-a6b9-f839c3715a3c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encoding">
+      <UniqueIdentifier>{018918b7-3854-4e4b-a4a2-b1a9ae6baa79}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encoding\der">
+      <UniqueIdentifier>{e5292d6c-85d0-4532-94a4-76b73e5e518f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\encrypt">
+      <UniqueIdentifier>{82456bf6-c573-4f74-936f-227b7d009c1a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\impl">
+      <UniqueIdentifier>{211f0360-e14a-46db-a40e-20a82d2c827f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\in-memory-storage">
+      <UniqueIdentifier>{1ad1fe80-c366-4d48-9c27-5744a17c8d7c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\lp">
+      <UniqueIdentifier>{2a7fc4bb-477e-4d18-9dd6-194583a13f16}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security">
+      <UniqueIdentifier>{5c69de44-8f83-4736-829c-ff3aa66174ea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\certificate">
+      <UniqueIdentifier>{d318df27-d2e4-476b-99aa-e1d4c5726516}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\pib">
+      <UniqueIdentifier>{9b7bc412-b32f-463e-979b-fb88761a1dbe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\pib\detail">
+      <UniqueIdentifier>{95e85d4c-13b4-4204-bb4a-03254d05100b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\tpm">
+      <UniqueIdentifier>{9c857923-54f8-41a8-8f40-7015f3aab56c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\v2">
+      <UniqueIdentifier>{03eded82-837c-49db-b8a7-533f93c9836c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\security\v2\validator-config">
+      <UniqueIdentifier>{0970a4d3-e0d0-4b8b-b06c-3b2cbdc62810}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sync">
+      <UniqueIdentifier>{0b19fc06-9b67-4d95-b8b2-9e39d3ccefa6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sync\detail">
+      <UniqueIdentifier>{2b9bd5dd-0121-4113-b944-261105dd295a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\transport">
+      <UniqueIdentifier>{ea4fbcf8-3009-4504-b413-6f80c4aa267c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\util">
+      <UniqueIdentifier>{c02e8a26-a7ec-4f00-baa3-c6bb8eb7b7fe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\util\regex">
+      <UniqueIdentifier>{c1e558a0-a60f-4ad8-9e5e-255520134fd3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\c\control-parameters.h">
-      <Filter>Source Files\src\c</Filter>
+    <ClInclude Include="framework.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\control-response.h">
-      <Filter>Source Files\src\c</Filter>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\data.h">
-      <Filter>Source Files\src\c</Filter>
+    <ClInclude Include="..\..\contrib\apache\apr_base64.h">
+      <Filter>Source Files\contrib\apache</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\delegation-set.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\forwarding-flags-impl.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\interest.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\key-locator.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\name.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\network-nack.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\registration-options.h">
-      <Filter>Source Files\src\c</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\encoding\element-listener.h">
-      <Filter>Source Files\src\c\encoding</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\encoding\element-reader.h">
-      <Filter>Source Files\src\c\encoding</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\encoding\tlv-0_2-wire-format.h">
-      <Filter>Source Files\src\c\encoding</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\c\encoding\tlv-0_3-wire-format.h">
-      <Filter>Source Files\src\c\encoding</Filter>
+    <ClInclude Include="..\..\contrib\murmur-hash\murmur-hash.h">
+      <Filter>Source Files\contrib\murmur-hash</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\c\encoding\tlv\tlv.h">
       <Filter>Source Files\src\c\encoding\tlv</Filter>
@@ -216,8 +186,17 @@
     <ClInclude Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.h">
       <Filter>Source Files\src\c\encoding\tlv</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\encrypt\encrypted-content.h">
-      <Filter>Source Files\src\c\encrypt</Filter>
+    <ClInclude Include="..\..\src\c\encoding\element-listener.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\element-reader.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_2-wire-format.h">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\encoding\tlv-0_3-wire-format.h">
+      <Filter>Source Files\src\c\encoding</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\c\encrypt\algo\aes-algorithm.h">
       <Filter>Source Files\src\c\encrypt\algo</Filter>
@@ -228,6 +207,9 @@
     <ClInclude Include="..\..\src\c\encrypt\algo\des-algorithm.h">
       <Filter>Source Files\src\c\encrypt\algo</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\c\encrypt\encrypted-content.h">
+      <Filter>Source Files\src\c\encrypt</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\c\lp\congestion-mark.h">
       <Filter>Source Files\src\c\lp</Filter>
     </ClInclude>
@@ -236,6 +218,33 @@
     </ClInclude>
     <ClInclude Include="..\..\src\c\lp\lp-packet.h">
       <Filter>Source Files\src\c\lp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\ec-private-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\ec-public-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\rsa-private-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\rsa-public-key.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\security\validity-period.h">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\socket-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\tcp-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\udp-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\c\transport\unix-transport.h">
+      <Filter>Source Files\src\c\transport</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\c\util\blob.h">
       <Filter>Source Files\src\c\util</Filter>
@@ -258,35 +267,35 @@
     <ClInclude Include="..\..\src\c\util\time.h">
       <Filter>Source Files\src\c\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\security\ec-private-key.h">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClInclude Include="..\..\src\c\control-parameters.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\security\ec-public-key.h">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClInclude Include="..\..\src\c\control-response.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\security\rsa-private-key.h">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClInclude Include="..\..\src\c\data.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\security\rsa-public-key.h">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClInclude Include="..\..\src\c\delegation-set.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\security\validity-period.h">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClInclude Include="..\..\src\c\forwarding-flags-impl.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\contrib\apache\apr_base64.h">
-      <Filter>Source Files\contrib\apache</Filter>
+    <ClInclude Include="..\..\src\c\interest.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\contrib\murmur-hash\murmur-hash.h">
-      <Filter>Source Files\contrib\murmur-hash</Filter>
+    <ClInclude Include="..\..\src\c\key-locator.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\encoding\element-listener.hpp">
-      <Filter>Source Files\src\encoding</Filter>
+    <ClInclude Include="..\..\src\c\name.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\encoding\tlv-decoder.hpp">
-      <Filter>Source Files\src\encoding</Filter>
+    <ClInclude Include="..\..\src\c\network-nack.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\encoding\tlv-encoder.hpp">
-      <Filter>Source Files\src\encoding</Filter>
+    <ClInclude Include="..\..\src\c\registration-options.h">
+      <Filter>Source Files\src\c</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\encoding\der\der-exception.hpp">
       <Filter>Source Files\src\encoding\der</Filter>
@@ -296,6 +305,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\encoding\der\der-node-type.hpp">
       <Filter>Source Files\src\encoding\der</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\tlv-decoder.hpp">
+      <Filter>Source Files\src\encoding</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\encoding\tlv-encoder.hpp">
+      <Filter>Source Files\src\encoding</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\impl\delayed-call-table.hpp">
       <Filter>Source Files\src\impl</Filter>
@@ -308,9 +323,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\impl\registered-prefix-table.hpp">
       <Filter>Source Files\src\impl</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\node.hpp">
-      <Filter>Source Files\src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\lp\congestion-mark.hpp">
       <Filter>Source Files\src\lp</Filter>
@@ -327,9 +339,6 @@
     <ClInclude Include="..\..\src\security\pib\detail\pib-key-impl.hpp">
       <Filter>Source Files\src\security\pib\detail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\sync\digest-tree.hpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\sync\detail\invertible-bloom-lookup-table.hpp">
       <Filter>Source Files\src\sync\detail</Filter>
     </ClInclude>
@@ -342,20 +351,11 @@
     <ClInclude Include="..\..\src\sync\detail\psync-user-prefixes.hpp">
       <Filter>Source Files\src\sync\detail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\util\boost-info-parser.hpp">
-      <Filter>Source Files\src\util</Filter>
+    <ClInclude Include="..\..\src\sync\digest-tree.hpp">
+      <Filter>Source Files\src\sync</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\util\command-interest-generator.hpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\util\config-file.hpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\util\dynamic-uint8-vector.hpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\util\sqlite3-statement.hpp">
-      <Filter>Source Files\src\util</Filter>
+    <ClInclude Include="..\..\src\transport\async-socket-transport.hpp">
+      <Filter>Source Files\src\transport</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\regex\ndn-regex-backref-manager.hpp">
       <Filter>Source Files\src\util\regex</Filter>
@@ -384,46 +384,31 @@
     <ClInclude Include="..\..\src\util\regex\ndn-regex-top-matcher.hpp">
       <Filter>Source Files\src\util\regex</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\ndn-ind\ndn-ind-config.h">
-      <Filter>Header Files</Filter>
+    <ClInclude Include="..\..\src\util\boost-info-parser.hpp">
+      <Filter>Source Files\src\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\transport\socket-transport.h">
-      <Filter>Source Files\src\c\transport</Filter>
+    <ClInclude Include="..\..\src\util\command-interest-generator.hpp">
+      <Filter>Source Files\src\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\transport\tcp-transport.h">
-      <Filter>Source Files\src\c\transport</Filter>
+    <ClInclude Include="..\..\src\util\config-file.hpp">
+      <Filter>Source Files\src\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\c\transport\udp-transport.h">
-      <Filter>Source Files\src\c\transport</Filter>
+    <ClInclude Include="..\..\src\util\dynamic-uint8-vector.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\sqlite3-statement.hpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\node.hpp">
+      <Filter>Source Files\src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\c\control-parameters_c.c">
-      <Filter>Source Files\src\c</Filter>
+    <ClCompile Include="..\..\contrib\apache\apr_base64.c">
+      <Filter>Source Files\contrib\apache</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\c\errors.c">
-      <Filter>Source Files\src\c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\interest_c.c">
-      <Filter>Source Files\src\c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\name_c.c">
-      <Filter>Source Files\src\c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\network-nack_c.c">
-      <Filter>Source Files\src\c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\registration-options.c">
-      <Filter>Source Files\src\c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\encoding\element-reader.c">
-      <Filter>Source Files\src\c\encoding</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\encoding\tlv-0_2-wire-format_c.c">
-      <Filter>Source Files\src\c\encoding</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\encoding\tlv-0_3-wire-format_c.c">
-      <Filter>Source Files\src\c\encoding</Filter>
+    <ClCompile Include="..\..\contrib\murmur-hash\murmur-hash.c">
+      <Filter>Source Files\contrib\murmur-hash</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\c\encoding\tlv\tlv-control-parameters.c">
       <Filter>Source Files\src\c\encoding\tlv</Filter>
@@ -464,6 +449,15 @@
     <ClCompile Include="..\..\src\c\encoding\tlv\tlv-structure-decoder.c">
       <Filter>Source Files\src\c\encoding\tlv</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\element-reader.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_2-wire-format_c.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\encoding\tlv-0_3-wire-format_c.c">
+      <Filter>Source Files\src\c\encoding</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\c\encrypt\algo\aes-algorithm_c.c">
       <Filter>Source Files\src\c\encrypt\algo</Filter>
     </ClCompile>
@@ -478,6 +472,24 @@
     </ClCompile>
     <ClCompile Include="..\..\src\c\lp\incoming-face-id_c.c">
       <Filter>Source Files\src\c\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\ec-private-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\ec-public-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\rsa-private-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\security\rsa-public-key.c">
+      <Filter>Source Files\src\c\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\transport\socket-transport.c">
+      <Filter>Source Files\src\c\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\c\transport\tcp-transport_c.c">
+      <Filter>Source Files\src\c\transport</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\c\util\blob_c.c">
       <Filter>Source Files\src\c\util</Filter>
@@ -497,23 +509,95 @@
     <ClCompile Include="..\..\src\c\util\time.c">
       <Filter>Source Files\src\c\util</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\c\security\ec-private-key.c">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClCompile Include="..\..\src\c\control-parameters_c.c">
+      <Filter>Source Files\src\c</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\c\security\ec-public-key.c">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClCompile Include="..\..\src\c\errors.c">
+      <Filter>Source Files\src\c</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\c\security\rsa-private-key.c">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClCompile Include="..\..\src\c\interest_c.c">
+      <Filter>Source Files\src\c</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\c\security\rsa-public-key.c">
-      <Filter>Source Files\src\c\security</Filter>
+    <ClCompile Include="..\..\src\c\name_c.c">
+      <Filter>Source Files\src\c</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\contrib\murmur-hash\murmur-hash.c">
-      <Filter>Source Files\contrib\murmur-hash</Filter>
+    <ClCompile Include="..\..\src\c\network-nack_c.c">
+      <Filter>Source Files\src\c</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\contrib\apache\apr_base64.c">
-      <Filter>Source Files\contrib\apache</Filter>
+    <ClCompile Include="..\..\src\c\registration-options.c">
+      <Filter>Source Files\src\c</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\element-listener-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_2-wire-format-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\tlv-0_3-wire-format-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\aes-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\chacha20-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\algo\des-algorithm-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt\algo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encrypt\encrypted-content-lite.cpp">
+      <Filter>Source Files\src\lite\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\congestion-mark-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\incoming-face-id-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\lp\lp-packet-lite.cpp">
+      <Filter>Source Files\src\lite\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\ec-private-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\ec-public-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\rsa-private-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\rsa-public-key-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\security\validity-period-lite.cpp">
+      <Filter>Source Files\src\lite\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\transport\tcp-transport-lite.cpp">
+      <Filter>Source Files\src\lite\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\transport\udp-transport-lite.cpp">
+      <Filter>Source Files\src\lite\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\transport\unix-transport-lite.cpp">
+      <Filter>Source Files\src\lite\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\blob-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\crypto-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\dynamic-malloc-uint8-array-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\util\dynamic-uint8-array-lite.cpp">
+      <Filter>Source Files\src\lite\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\der\der-exception.cpp">
+      <Filter>Source Files\src\encoding\der</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encoding\der\der-node.cpp">
+      <Filter>Source Files\src\encoding\der</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\encoding\base64.cpp">
       <Filter>Source Files\src\encoding</Filter>
@@ -545,11 +629,17 @@
     <ClCompile Include="..\..\src\encoding\wire-format.cpp">
       <Filter>Source Files\src\encoding</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encoding\der\der-exception.cpp">
-      <Filter>Source Files\src\encoding\der</Filter>
+    <ClCompile Include="..\..\src\encrypt\access-manager-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encoding\der\der-node.cpp">
-      <Filter>Source Files\src\encoding\der</Filter>
+    <ClCompile Include="..\..\src\encrypt\decryptor-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\encrypted-content.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\encrypt\encryptor-v2.cpp">
+      <Filter>Source Files\src\encrypt</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\impl\delayed-call-table.cpp">
       <Filter>Source Files\src\impl</Filter>
@@ -563,17 +653,278 @@
     <ClCompile Include="..\..\src\impl\registered-prefix-table.cpp">
       <Filter>Source Files\src\impl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encrypt\access-manager-v2.cpp">
-      <Filter>Source Files\src\encrypt</Filter>
+    <ClCompile Include="..\..\src\in-memory-storage\in-memory-storage-retaining.cpp">
+      <Filter>Source Files\src\in-memory-storage</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encrypt\decryptor-v2.cpp">
-      <Filter>Source Files\src\encrypt</Filter>
+    <ClCompile Include="..\..\src\lp\congestion-mark.cpp">
+      <Filter>Source Files\src\lp</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encrypt\encrypted-content.cpp">
-      <Filter>Source Files\src\encrypt</Filter>
+    <ClCompile Include="..\..\src\lp\incoming-face-id.cpp">
+      <Filter>Source Files\src\lp</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\encrypt\encryptor-v2.cpp">
-      <Filter>Source Files\src\encrypt</Filter>
+    <ClCompile Include="..\..\src\lp\lp-packet.cpp">
+      <Filter>Source Files\src\lp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate-extension.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\certificate-subject-description.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\public-key.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\detail\pib-identity-impl.cpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\detail\pib-key-impl.cpp">
+      <Filter>Source Files\src\security\pib\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-certificate-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-identity.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-identity-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-key.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-key-container.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-memory.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\pib\pib-sqlite3.cpp">
+      <Filter>Source Files\src\security\pib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-file.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-memory.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-osx.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-memory.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-osx.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\tpm\tpm-private-key.cpp">
+      <Filter>Source Files\src\security\tpm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-checker.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-filter.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-name-relation.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator-config\config-rule.cpp">
+      <Filter>Source Files\src\security\v2\validator-config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-cache-v2.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-from-network.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-offline.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-storage.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\certificate-v2.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-container.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\trust-anchor-group.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-error.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-accept-all.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-command-interest.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-config.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-from-pib.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-policy-simple-hierarchy.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validation-state.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\validator.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\command-interest-preparer.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\command-interest-signer.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\key-chain.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\key-params.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\safe-bag.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\security-exception.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\signing-info.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\validator-null.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\validity-period.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\verification-helpers.cpp">
+      <Filter>Source Files\src\security</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\invertible-bloom-lookup-table.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-segment-publisher.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-state.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\detail\psync-user-prefixes.cpp">
+      <Filter>Source Files\src\sync\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\chrono-sync2013.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\digest-tree.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\full-psync2017.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\full-psync2017-with-users.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\sync\psync-producer-base.cpp">
+      <Filter>Source Files\src\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\async-tcp-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\async-unix-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\tcp-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\udp-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transport\unix-transport.cpp">
+      <Filter>Source Files\src\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-manager.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-set-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-matcher-base.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-repeat-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\regex\ndn-regex-top-matcher.cpp">
+      <Filter>Source Files\src\util\regex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\boost-info-parser.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\command-interest-generator.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\config-file.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\dynamic-uint8-vector.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\exponential-re-express.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\logging.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\memory-content-cache.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\segment-fetcher.cpp">
+      <Filter>Source Files\src\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\sqlite3-statement.cpp">
+      <Filter>Source Files\src\util</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\common.cpp">
       <Filter>Source Files\src</Filter>
@@ -641,66 +992,6 @@
     <ClCompile Include="..\..\src\threadsafe-face.cpp">
       <Filter>Source Files\src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\in-memory-storage\in-memory-storage-retaining.cpp">
-      <Filter>Source Files\src\in-memory-storage</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encoding\element-listener-lite.cpp">
-      <Filter>Source Files\src\lite\encoding</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encoding\tlv-0_2-wire-format-lite.cpp">
-      <Filter>Source Files\src\lite\encoding</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encoding\tlv-0_3-wire-format-lite.cpp">
-      <Filter>Source Files\src\lite\encoding</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encrypt\encrypted-content-lite.cpp">
-      <Filter>Source Files\src\lite\encrypt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encrypt\algo\aes-algorithm-lite.cpp">
-      <Filter>Source Files\src\lite\encrypt\algo</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encrypt\algo\chacha20-algorithm-lite.cpp">
-      <Filter>Source Files\src\lite\encrypt\algo</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\encrypt\algo\des-algorithm-lite.cpp">
-      <Filter>Source Files\src\lite\encrypt\algo</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\lp\congestion-mark-lite.cpp">
-      <Filter>Source Files\src\lite\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\lp\incoming-face-id-lite.cpp">
-      <Filter>Source Files\src\lite\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\lp\lp-packet-lite.cpp">
-      <Filter>Source Files\src\lite\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\util\blob-lite.cpp">
-      <Filter>Source Files\src\lite\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\util\crypto-lite.cpp">
-      <Filter>Source Files\src\lite\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\util\dynamic-malloc-uint8-array-lite.cpp">
-      <Filter>Source Files\src\lite\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\util\dynamic-uint8-array-lite.cpp">
-      <Filter>Source Files\src\lite\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\security\ec-private-key-lite.cpp">
-      <Filter>Source Files\src\lite\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\security\ec-public-key-lite.cpp">
-      <Filter>Source Files\src\lite\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\security\rsa-private-key-lite.cpp">
-      <Filter>Source Files\src\lite\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\security\rsa-public-key-lite.cpp">
-      <Filter>Source Files\src\lite\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\security\validity-period-lite.cpp">
-      <Filter>Source Files\src\lite\security</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\lite\control-parameters-lite.cpp">
       <Filter>Source Files\src\lite</Filter>
     </ClCompile>
@@ -736,279 +1027,6 @@
     </ClCompile>
     <ClCompile Include="..\..\src\lite\signature-lite.cpp">
       <Filter>Source Files\src\lite</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lp\congestion-mark.cpp">
-      <Filter>Source Files\src\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lp\incoming-face-id.cpp">
-      <Filter>Source Files\src\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lp\lp-packet.cpp">
-      <Filter>Source Files\src\lp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\certificate\certificate.cpp">
-      <Filter>Source Files\src\security\certificate</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\certificate\certificate-extension.cpp">
-      <Filter>Source Files\src\security\certificate</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\certificate\certificate-subject-description.cpp">
-      <Filter>Source Files\src\security\certificate</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\certificate\public-key.cpp">
-      <Filter>Source Files\src\security\certificate</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-certificate-container.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-identity.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-identity-container.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-key.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-key-container.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-memory.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\pib-sqlite3.cpp">
-      <Filter>Source Files\src\security\pib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\detail\pib-identity-impl.cpp">
-      <Filter>Source Files\src\security\pib\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\pib\detail\pib-key-impl.cpp">
-      <Filter>Source Files\src\security\pib\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-cache-v2.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-fetcher.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-from-network.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-fetcher-offline.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-storage.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\certificate-v2.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\trust-anchor-container.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\trust-anchor-group.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-error.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy-accept-all.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy-command-interest.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy-config.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy-from-pib.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-policy-simple-hierarchy.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validation-state.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validator.cpp">
-      <Filter>Source Files\src\security\v2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validator-config\config-checker.cpp">
-      <Filter>Source Files\src\security\v2\validator-config</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validator-config\config-filter.cpp">
-      <Filter>Source Files\src\security\v2\validator-config</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validator-config\config-name-relation.cpp">
-      <Filter>Source Files\src\security\v2\validator-config</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\v2\validator-config\config-rule.cpp">
-      <Filter>Source Files\src\security\v2\validator-config</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-back-end.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-file.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-memory.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-back-end-osx.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-memory.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-key-handle-osx.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\tpm\tpm-private-key.cpp">
-      <Filter>Source Files\src\security\tpm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\chrono-sync2013.cpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\digest-tree.cpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\full-psync2017.cpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\full-psync2017-with-users.cpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\psync-producer-base.cpp">
-      <Filter>Source Files\src\sync</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\detail\invertible-bloom-lookup-table.cpp">
-      <Filter>Source Files\src\sync\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\detail\psync-segment-publisher.cpp">
-      <Filter>Source Files\src\sync\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\detail\psync-state.cpp">
-      <Filter>Source Files\src\sync\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sync\detail\psync-user-prefixes.cpp">
-      <Filter>Source Files\src\sync\detail</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\boost-info-parser.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\command-interest-generator.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\config-file.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\dynamic-uint8-vector.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\exponential-re-express.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\logging.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\memory-content-cache.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\segment-fetcher.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\sqlite3-statement.cpp">
-      <Filter>Source Files\src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-manager.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-backref-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-component-set-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-matcher-base.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-pattern-list-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-pseudo-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-repeat-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\util\regex\ndn-regex-top-matcher.cpp">
-      <Filter>Source Files\src\util\regex</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\command-interest-preparer.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\command-interest-signer.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\key-chain.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\key-params.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\safe-bag.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\security-exception.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\signing-info.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\validator-null.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\validity-period.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\security\verification-helpers.cpp">
-      <Filter>Source Files\src\security</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\transport\socket-transport.c">
-      <Filter>Source Files\src\c\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\c\transport\tcp-transport_c.c">
-      <Filter>Source Files\src\c\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\transport\tcp-transport.cpp">
-      <Filter>Source Files\src\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\transport\transport.cpp">
-      <Filter>Source Files\src\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\transport\udp-transport.cpp">
-      <Filter>Source Files\src\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\transport\tcp-transport-lite.cpp">
-      <Filter>Source Files\src\lite\transport</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\lite\transport\udp-transport-lite.cpp">
-      <Filter>Source Files\src\lite\transport</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/contrib/murmur-hash/murmur-hash.c
+++ b/contrib/murmur-hash/murmur-hash.c
@@ -33,7 +33,7 @@ ndn_murmurHash3
   const uint32_t* blocks = (const uint32_t*)(dataToHash + nblocks * 4);
 
   int i;
-  for (i = -nblocks; i < 0; i++) {
+  for (i = -(int)nblocks; i < 0; i++) {
     // Note that this indexes backwards from the end of the array.
     uint32_t k2 = blocks[i];
 

--- a/examples/test-echo-consumer.cpp
+++ b/examples/test-echo-consumer.cpp
@@ -33,7 +33,11 @@
 
 #include <cstdlib>
 #include <iostream>
+#if NDN_IND_HAVE_UNISTD_H
 #include <unistd.h>
+#elif defined(_WIN32)
+#include "windows.h"
+#endif
 #include <ndn-ind/face.hpp>
 
 using namespace std;
@@ -91,7 +95,11 @@ int main(int argc, char** argv)
     while (counter.callbackCount_ < 1) {
       face.processEvents();
       // We need to sleep for a few milliseconds so we don't use 100% of the CPU.
+#if NDN_IND_HAVE_UNISTD_H
       usleep(10000);
+#elif defined(_WIN32)
+      Sleep(10);
+#endif
     }
   } catch (std::exception& e) {
     cout << "exception: " << e.what() << endl;

--- a/examples/test-echo-consumer.cpp
+++ b/examples/test-echo-consumer.cpp
@@ -33,12 +33,12 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <ndn-ind/face.hpp>
 #if NDN_IND_HAVE_UNISTD_H
 #include <unistd.h>
 #elif defined(_WIN32)
 #include "windows.h"
 #endif
-#include <ndn-ind/face.hpp>
 
 using namespace std;
 using namespace ndn;

--- a/include/ndn-ind/c/common.h
+++ b/include/ndn-ind/c/common.h
@@ -76,62 +76,62 @@ ndn_getNowMilliseconds();
  * applications should use the static inline API method
  * Face::getMaxNdnPacketSize() which is equivalent.
  */
-static const size_t MAX_NDN_PACKET_SIZE = 8800;
+enum { MAX_NDN_PACKET_SIZE = 8800 };
 
 /**
  * The size in bytes of a SHA-256 digest. We define this separately so that we
  * don't have to include the openssl header everywhere.
  */
-static const size_t ndn_SHA256_DIGEST_SIZE = 32;
+enum { ndn_SHA256_DIGEST_SIZE = 32 };
 
 /**
  * The block size in bytes for the AES algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_AES_BLOCK_LENGTH = 16;
+enum { ndn_AES_BLOCK_LENGTH = 16 };
 
 /**
  * The key size in bytes for the AES 128 algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_AES_128_KEY_LENGTH = 16;
+enum { ndn_AES_128_KEY_LENGTH = 16 };
 
 /**
  * The key size in bytes for the AES 256 algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_AES_256_KEY_LENGTH = 32;
+enum { ndn_AES_256_KEY_LENGTH = 32 };
 
 /**
  * The key size in bytes for the DES EDE3 algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_DES_EDE3_KEY_LENGTH = 24;
+enum { ndn_DES_EDE3_KEY_LENGTH = 24 };
 
 /**
  * The block size in bytes for the DES algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_DES_BLOCK_LENGTH = 8;
+enum { ndn_DES_BLOCK_LENGTH = 8 };
 
 /**
  * The size in bytes of a Poly1305 block (and of the ChaCha20-Poly1305 tag). We
  * define this separately so that we don't have to include the openssl header
  * everywhere.
  */
-static const size_t ndn_POLY1305_BLOCK_LENGTH = 16;
+enum { ndn_POLY1305_BLOCK_LENGTH = 16 };
 
 /**
  * The key size in bytes for the ChaCha20 algorithm. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_CHACHA20_KEY_LENGTH = 32;
+enum { ndn_CHACHA20_KEY_LENGTH = 32 };
 
 /**
  * The key size in bytes for the ChaCha20 nonce. We define this separately
  * so that we don't have to include the openssl header everywhere.
  */
-static const size_t ndn_CHACHA20_NONCE_LENGTH = 12;
+enum { ndn_CHACHA20_NONCE_LENGTH = 12 };
 
 #ifdef __cplusplus
 }

--- a/include/ndn-ind/c/common.h
+++ b/include/ndn-ind/c/common.h
@@ -7,7 +7,7 @@
  * Original file: include/ndn-cpp/c/common.h
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -36,6 +36,16 @@
 #include "../ndn-ind-config.h"
 #include <stdint.h>
 #include <stddef.h>
+
+#if defined(_WIN32)
+  #ifdef NDN_IND_EXPORTS
+    #define ndn_ind_dll __declspec(dllexport)
+  #else
+    #define ndn_ind_dll __declspec(dllimport)
+  #endif
+#else
+  #define ndn_ind_dll
+#endif
 
 #if NDN_IND_HAVE_ATTRIBUTE_DEPRECATED
   #define DEPRECATED_IN_NDN_IND __attribute__((deprecated))
@@ -66,7 +76,7 @@ typedef double ndn_MillisecondsSince1970;
  * @return The current time in milliseconds since 1/1/1970 UTC, including
  * fractions of a millisecond (according to timeval.tv_usec).
  */
-ndn_MillisecondsSince1970
+ndn_ind_dll ndn_MillisecondsSince1970
 ndn_getNowMilliseconds();
 
 /**

--- a/include/ndn-ind/c/errors.h
+++ b/include/ndn-ind/c/errors.h
@@ -22,6 +22,8 @@
 #ifndef NDN_ERRORS_H
 #define NDN_ERRORS_H
 
+#include "common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -95,7 +97,7 @@ typedef enum {
  * @param error the error code
  * @return the error string or "unrecognized ndn_Error code"
  */
-const char *
+ndn_ind_dll const char *
 ndn_getErrorString(int error);
 
 #ifdef __cplusplus

--- a/include/ndn-ind/c/transport/transport-types.h
+++ b/include/ndn-ind/c/transport/transport-types.h
@@ -21,6 +21,9 @@
 #ifndef NDN_TRANSPORT_TYPES_H
 #define NDN_TRANSPORT_TYPES_H
 
+#if defined(_WIN32)
+#include <winsock2.h>
+#endif
 #include "../encoding/element-reader-types.h"
 
 #ifdef __cplusplus
@@ -28,7 +31,11 @@ extern "C" {
 #endif
 
 struct ndn_SocketTransport {
+#if defined(_WIN32)
+  SOCKET socketDescriptor; /**< INVALID_SOCKET if not connected */
+#else
   int socketDescriptor; /**< -1 if not connected */
+#endif
   struct ndn_ElementReader elementReader;
 };
 

--- a/include/ndn-ind/common.hpp
+++ b/include/ndn-ind/common.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cpp
  *
  * Summary of Changes: Use NDN_IND macros. Add support functions for std::chrono. Remove ndnboost.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -99,7 +100,7 @@ namespace ndn {
  * @param arrayLength The number of bytes in array.
  * @param result The output stream to write to.
  */
-void
+ndn_ind_dll void
 toHex(const uint8_t* array, size_t arrayLength, std::ostringstream& result);
 
 /**
@@ -119,7 +120,7 @@ toHex(const std::vector<uint8_t>& array, std::ostringstream& result)
  * @param arrayLength The number of bytes in array.
  * @return The hex string.
  */
-std::string
+ndn_ind_dll std::string
 toHex(const uint8_t* array, size_t arrayLength);
 
 /**
@@ -137,7 +138,7 @@ toHex(const std::vector<uint8_t>& array)
  * Modify str in place to erase whitespace on the left and right.
  * @param str The string to modify.
  */
-void
+ndn_ind_dll void
 ndn_trim(std::string& str);
 
 /**
@@ -146,7 +147,7 @@ ndn_trim(std::string& str);
  * @param s2 The second string to compare.
  * @return True if the strings are equal, ignoring case.
  */
-bool
+ndn_ind_dll bool
 equalsIgnoreCase(const std::string& s1, const std::string& s2);
 
 /**
@@ -214,7 +215,7 @@ fromMilliseconds(double ms)
  * fraction.
  * @return The ISO string.
  */
-std::string
+ndn_ind_dll std::string
 toIsoString(std::chrono::system_clock::time_point time, bool includeFraction = false);
 
 /**
@@ -223,7 +224,7 @@ toIsoString(std::chrono::system_clock::time_point time, bool includeFraction = f
  * @return The time.
  * @throws runtime_error for error parsing the isoString.
  */
-std::chrono::system_clock::time_point
+ndn_ind_dll std::chrono::system_clock::time_point
 fromIsoString(const std::string& isoString);
 
 }

--- a/include/ndn-ind/control-parameters.hpp
+++ b/include/ndn-ind/control-parameters.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/control-parameters.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -49,7 +49,7 @@ namespace ndn {
  * ControlParameters which is used, for example, in the command interest to
  * register a prefix with a forwarder.
  */
-class ControlParameters {
+class ndn_ind_dll ControlParameters {
 public:
   ControlParameters()
   : hasName_(false), faceId_(-1), localControlFeature_(-1), origin_(-1), cost_(-1),

--- a/include/ndn-ind/control-response.hpp
+++ b/include/ndn-ind/control-response.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/control-response.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -34,7 +46,7 @@ namespace ndn {
  * register prefix control command to a forwarder.
  * @see http://redmine.named-data.net/projects/nfd/wiki/ControlCommand
  */
-class ControlResponse {
+class ndn_ind_dll ControlResponse {
 public:
   /**
    * Create a new ControlResponse where all values are unspecified.

--- a/include/ndn-ind/data.hpp
+++ b/include/ndn-ind/data.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/data.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -34,7 +46,7 @@ namespace ndn {
 
 class LpPacket;
 
-class Data {
+class ndn_ind_dll Data {
 public:
   /**
    * Create a new Data object with default values and where the signature is a blank Sha256WithRsaSignature.

--- a/include/ndn-ind/delegation-set.hpp
+++ b/include/ndn-ind/delegation-set.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/delegation-set.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -35,7 +47,7 @@ namespace ndn {
  * possible duplicates (in which case a DelegationSet really holds a "list" and
  * not necessarily a "set").
  */
-class DelegationSet {
+class ndn_ind_dll DelegationSet {
 public:
   /**
    * Create a DelegationSet with an empty list of delegations.

--- a/include/ndn-ind/digest-sha256-signature.hpp
+++ b/include/ndn-ind/digest-sha256-signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/digest-sha256-signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
  * are only the SHA256 digest) and an empty SignatureInfo for a data packet or
  * signed interest.
  */
-class DigestSha256Signature : public Signature {
+class ndn_ind_dll DigestSha256Signature : public Signature {
 public:
   DigestSha256Signature()
   : changeCount_(0)

--- a/include/ndn-ind/encoding/base64.hpp
+++ b/include/ndn-ind/encoding/base64.hpp
@@ -8,7 +8,7 @@
  * Original file: src/encoding/base64.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ namespace ndn {
  * writing to a file).  If omitted, do not add newlines.
  * @return The base64 string.
  */
-std::string
+ndn_ind_dll std::string
 toBase64(const uint8_t* array, size_t arrayLength, bool addNewlines = false);
 
 /**
@@ -70,7 +70,7 @@ toBase64(const std::vector<uint8_t>& array, bool addNewlines = false)
  * @param output Write the result to output starting at index 0, calling
  * output.resize() as needed.
  */
-void
+ndn_ind_dll void
 fromBase64(const std::string& input, std::vector<uint8_t>& output);
 
 

--- a/include/ndn-ind/encoding/element-listener.hpp
+++ b/include/ndn-ind/encoding/element-listener.hpp
@@ -8,7 +8,7 @@
  * Original file: src/encoding/element-listener.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets. Put element-listener.hpp in API.
+ * Summary of Changes: Add readRawPackets. Put element-listener.hpp in API. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -42,7 +42,7 @@ namespace ndn {
  * An ElementListener extends an ndn_ElementListener struct to proved an abstract virtual onReceivedElement function which wraps
  * the onReceivedElement used by the ndn_ElementListener struct.  You must extend this class to override onReceivedElement.
  */
-class ElementListener : public ndn_ElementListener {
+class ndn_ind_dll ElementListener : public ndn_ElementListener {
 public:
   ElementListener();
 

--- a/include/ndn-ind/encoding/oid.hpp
+++ b/include/ndn-ind/encoding/oid.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/oid.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Yingdi Yu <yingdi@cs.ucla.edu>
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
@@ -23,12 +35,14 @@
 #ifndef NDN_OID_HPP
 #define NDN_OID_HPP
 
+#include "../c/common.h"
+
 #include <vector>
 #include <string>
 
 namespace ndn {
 
-class OID {
+class ndn_ind_dll OID {
 public:
   OID ()
   {

--- a/include/ndn-ind/encoding/protobuf-tlv.hpp
+++ b/include/ndn-ind/encoding/protobuf-tlv.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/protobuf-tlv.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -42,7 +54,7 @@ namespace ndn {
  * inside an outer "typeless" message.
  *
  */
-class ProtobufTlv {
+class ndn_ind_dll ProtobufTlv {
 public:
   /**
    * Encode the Protobuf Message object as NDN-TLV.

--- a/include/ndn-ind/encoding/tlv-0_1-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-0_1-wire-format.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/tlv-0_1-wire-format.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * the same except that Tlv0_1_1WireFormat adds support for
  * Sha256WithEcdsaSignature.
  */
-class Tlv0_1WireFormat : public Tlv0_1_1WireFormat {
+class ndn_ind_dll Tlv0_1WireFormat : public Tlv0_1_1WireFormat {
 public:
   /**
    * Get a singleton instance of a Tlv0_1WireFormat.

--- a/include/ndn-ind/encoding/tlv-0_1_1-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-0_1_1-wire-format.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/tlv-0_1_1-wire-format.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * the same except that Tlv0_2WireFormat adds support for the name component
  * type ImplicitSha256Digest.
  */
-class Tlv0_1_1WireFormat : public Tlv0_2WireFormat {
+class ndn_ind_dll Tlv0_1_1WireFormat : public Tlv0_2WireFormat {
 public:
   /**
    * Get a singleton instance of a Tlv0_1_1WireFormat.

--- a/include/ndn-ind/encoding/tlv-0_2-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-0_2-wire-format.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/tlv-0_2-wire-format.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * These methods call the ones for version version 0.3 except where the format
  * is different for version 0.2.
  */
-class Tlv0_2WireFormat : public Tlv0_3WireFormat {
+class ndn_ind_dll Tlv0_2WireFormat : public Tlv0_3WireFormat {
 public:
   /**
    * Encode interest in NDN-TLV and return the encoding.

--- a/include/ndn-ind/encoding/tlv-0_3-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-0_3-wire-format.hpp
@@ -3,6 +3,18 @@
  * Copyright (C) 2020 Operant Networks, Incorporated.
  * @author: Jeff Thompson <jefft0@gmail.com>
  *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/tlv-0_3-wire-format.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -31,7 +43,7 @@ namespace ndn {
  * implement encoding and decoding using NDN-TLV version 0.3.  To always use
  * the preferred version NDN-TLV, you should use the class TlvWireFormat.
  */
-class Tlv0_3WireFormat : public WireFormat {
+class ndn_ind_dll Tlv0_3WireFormat : public WireFormat {
 public:
   /**
    * Encode name in NDN-TLV and return the encoding.

--- a/include/ndn-ind/encoding/tlv-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-wire-format.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encoding/tlv-wire-format.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
  * A TlvWireFormat extends WireFormat to override its virtual methods to implement encoding and decoding
  * using the preferred implementation of NDN-TLV.
  */
-class TlvWireFormat : public Tlv0_2WireFormat {
+class ndn_ind_dll TlvWireFormat : public Tlv0_2WireFormat {
 public:
   /**
    * Get a singleton instance of a TlvWireFormat.  Assuming that the default wire format was set with

--- a/include/ndn-ind/encoding/wire-format.hpp
+++ b/include/ndn-ind/encoding/wire-format.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/encoding/wire-format.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused methods.
+ * Summary of Changes: Remove unused methods. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ class Signature;
 class DelegationSet;
 class EncryptedContent;
 
-class WireFormat {
+class ndn_ind_dll WireFormat {
 public:
   /**
    * Encode name and return the encoding. Your derived class should override.

--- a/include/ndn-ind/encrypt/access-manager-v2.hpp
+++ b/include/ndn-ind/encrypt/access-manager-v2.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/encrypt/access-manager-v2.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -57,7 +57,7 @@ const std::chrono::nanoseconds DEFAULT_KDK_FRESHNESS_PERIOD =
  * For the meaning of "KDK", etc. see:
  * https://github.com/named-data/name-based-access-control/blob/new/docs/spec.rst
  */
-class AccessManagerV2 {
+class ndn_ind_dll AccessManagerV2 {
 public:
   /**
    * Create an AccessManagerV2 to serve the KDK or GCK that is encrypted by each

--- a/include/ndn-ind/encrypt/decryptor-v2.hpp
+++ b/include/ndn-ind/encrypt/decryptor-v2.hpp
@@ -9,7 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cpp
  *
  * Summary of Changes: Use std::chrono. Support ChaCha20-Ploy1305, GCK,
- *   encrypted Interest.
+ *   encrypted Interest. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -50,7 +50,7 @@ namespace ndn {
  * "KDK", etc. see:
  * https://github.com/named-data/name-based-access-control/blob/new/docs/spec.rst
  */
-class DecryptorV2 {
+class ndn_ind_dll DecryptorV2 {
 public:
   typedef func_lib::function<void(const Blob& plainData)> DecryptSuccessCallback;
 

--- a/include/ndn-ind/encrypt/encrypt-error.hpp
+++ b/include/ndn-ind/encrypt/encrypt-error.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/encrypt/encrypt-error.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
  * EncryptError holds the ErrorCode enum and OnError callback definition for
  * errors from the encrypt library.
  */
-class EncryptError {
+class ndn_ind_dll EncryptError {
 public:
   enum ErrorCode {
     KekRetrievalFailure  = 1,

--- a/include/ndn-ind/encrypt/encrypted-content.hpp
+++ b/include/ndn-ind/encrypt/encrypted-content.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/encrypt/encrypted-content.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused methods.
+ * Summary of Changes: Remove unused methods. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -46,7 +46,7 @@ namespace ndn {
  * representing encrypted content.
  * @note This class is an experimental feature. The API may change.
  */
-class EncryptedContent {
+class ndn_ind_dll EncryptedContent {
 public:
   /**
    * Create an EncryptedContent where all the values are unspecified.

--- a/include/ndn-ind/encrypt/encryptor-v2.hpp
+++ b/include/ndn-ind/encrypt/encryptor-v2.hpp
@@ -9,7 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cpp
  *
  * Summary of Changes: Use std::chrono. Support ChaCha20-Ploy1305, GCK,
- *   encrypted Interest.
+ *   encrypted Interest. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -49,16 +49,16 @@ class TestEncryptorV2_EnumerateDataFromInMemoryStorage_Test;
 
 namespace ndn {
 
-const std::chrono::nanoseconds RETRY_DELAY_AFTER_NACK = std::chrono::seconds(1);
-const std::chrono::nanoseconds RETRY_DELAY_KEK_RETRIEVAL = std::chrono::minutes(1);
-const std::chrono::nanoseconds DEFAULT_CK_FRESHNESS_PERIOD = std::chrono::hours(1);
+ndn_ind_dll extern const std::chrono::nanoseconds RETRY_DELAY_AFTER_NACK;
+ndn_ind_dll extern const std::chrono::nanoseconds RETRY_DELAY_KEK_RETRIEVAL;
+ndn_ind_dll extern const std::chrono::nanoseconds DEFAULT_CK_FRESHNESS_PERIOD;
 
 /**
  * EncryptorV2 encrypts the requested content for name-based access control (NAC)
  * using security v2. For the meaning of "KEK", etc. see:
  * https://github.com/named-data/name-based-access-control/blob/new/docs/spec.rst
  */
-class EncryptorV2 {
+class ndn_ind_dll EncryptorV2 {
 public:
   typedef func_lib::function<void
     (const ptr_lib::shared_ptr<EncryptedContent>& encryptedContent)> OnEncryptSuccess;

--- a/include/ndn-ind/exclude.hpp
+++ b/include/ndn-ind/exclude.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/exclude.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -42,7 +42,7 @@ namespace ndn {
 /**
  * An Exclude holds a vector of Exclude::Entry.
  */
-class Exclude {
+class ndn_ind_dll Exclude {
 public:
   /**
    * Create a new Exclude with no entries.

--- a/include/ndn-ind/face.hpp
+++ b/include/ndn-ind/face.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/face.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -95,7 +95,7 @@ class KeyChain;
 /**
  * The Face class provides the main methods for NDN communication.
  */
-class Face {
+class ndn_ind_dll Face {
 public:
   /**
    * Create a new Face for communication with an NDN hub with the given Transport object and connectionInfo.

--- a/include/ndn-ind/forwarding-flags.hpp
+++ b/include/ndn-ind/forwarding-flags.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/forwarding-flags.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -41,7 +41,7 @@ namespace ndn {
 /**
  * @deprecated Use RegistrationOptions.
  */
-class ForwardingFlags : public RegistrationOptions {
+class ndn_ind_dll ForwardingFlags : public RegistrationOptions {
 public:
   /**
    * Create a new ForwardingFlags with "childInherit" set and all other flags cleared.

--- a/include/ndn-ind/generic-signature.hpp
+++ b/include/ndn-ind/generic-signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/generic-signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * types. When decoding a packet, if the type of SignatureInfo is not
  * recognized, the library creates a GenericSignature.
  */
-class GenericSignature : public Signature {
+class ndn_ind_dll GenericSignature : public Signature {
 public:
   /**
    * Create a new GenericSignature with default values.

--- a/include/ndn-ind/hmac-with-sha256-signature.hpp
+++ b/include/ndn-ind/hmac-with-sha256-signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/hmac-with-sha256-signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * An HmacWithSha256Signature extends Signature and holds the signature bits and
  * other info representing an HmacWithSha256 signature in a data packet.
  */
-class HmacWithSha256Signature : public Signature {
+class ndn_ind_dll HmacWithSha256Signature : public Signature {
 public:
   HmacWithSha256Signature()
   : changeCount_(0)

--- a/include/ndn-ind/in-memory-storage/in-memory-storage-retaining.hpp
+++ b/include/ndn-ind/in-memory-storage/in-memory-storage-retaining.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/in-memory-storage/in-memory-storage-retaining.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2018-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/ims/in-memory-storage-persistent.hpp
@@ -40,7 +52,7 @@ namespace ndn {
  * Note: In ndn-cxx, this class is called InMemoryStoragePersistent, but
  * "persistent" misleadingly sounds like persistent on-disk storage.
  */
-class InMemoryStorageRetaining {
+class ndn_ind_dll InMemoryStorageRetaining {
 public:
   /**
    * Insert a Data packet. If a Data packet with the same name, including the

--- a/include/ndn-ind/interest-filter.hpp
+++ b/include/ndn-ind/interest-filter.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/interest-filter.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
  * An InterestFilter holds a Name prefix and optional regex match expression for
  * use in Face::setInterestFilter.
  */
-class InterestFilter {
+class ndn_ind_dll InterestFilter {
 public:
   /**
    * Create an InterestFilter to match any Interest whose name starts with the

--- a/include/ndn-ind/interest.hpp
+++ b/include/ndn-ind/interest.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/interest.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Use std::chrono.
+ * Summary of Changes: Use NDN_IND macros. Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -52,7 +52,7 @@ class Data;
 /**
  * An Interest holds a Name and other fields for an interest.
  */
-class Interest {
+class ndn_ind_dll Interest {
 public:
   /**
    * Create a new Interest with the given name and interest lifetime and "none" for other values.

--- a/include/ndn-ind/key-locator.hpp
+++ b/include/ndn-ind/key-locator.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/key-locator.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
 
 class Signature;
 
-class KeyLocator {
+class ndn_ind_dll KeyLocator {
 public:
   KeyLocator()
   : type_((ndn_KeyLocatorType)-1), changeCount_(0)

--- a/include/ndn-ind/link.hpp
+++ b/include/ndn-ind/link.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/link.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * content is an encoded delegation set. The format is defined in "link.pdf"
  * attached to Redmine issue http://redmine.named-data.net/issues/2587 .
  */
-class Link : public Data {
+class ndn_ind_dll Link : public Data {
 public:
   /**
    * Create a Link with default values and where the list of delegations is

--- a/include/ndn-ind/lite/control-parameters-lite.hpp
+++ b/include/ndn-ind/lite/control-parameters-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/control-parameters-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * ControlParameters which is used, for example, in the command interest to
  * register a prefix with a forwarder.
  */
-class ControlParametersLite : private ndn_ControlParameters {
+class ndn_ind_dll ControlParametersLite : private ndn_ControlParameters {
 public:
   /**
    * Create a ControlParametersLite to use the pre-allocated nameComponents and

--- a/include/ndn-ind/lite/control-response-lite.hpp
+++ b/include/ndn-ind/lite/control-response-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/control-response-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * ControlResponse which is used, for example, in the response from sending a
  * register prefix control command to a forwarder.
  */
-class ControlResponseLite : private ndn_ControlResponse {
+class ndn_ind_dll ControlResponseLite : private ndn_ControlResponse {
 public:
   /**
    * Create a ControlResponseLite to use the pre-allocated nameComponents and

--- a/include/ndn-ind/lite/data-lite.hpp
+++ b/include/ndn-ind/lite/data-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/data-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
 /**
  * A DataLite holds a NameLite and other fields to represent an NDN Data packet.
  */
-class DataLite : private ndn_Data {
+class ndn_ind_dll DataLite : private ndn_Data {
 public:
   /**
    * Create a DataLite with the pre-allocated nameComponents and

--- a/include/ndn-ind/lite/delegation-set-lite.hpp
+++ b/include/ndn-ind/lite/delegation-set-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/delegation-set-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -27,7 +39,7 @@
 
 namespace ndn {
 
-class DelegationSetLite {
+class ndn_ind_dll DelegationSetLite {
 public:
   class Delegation : private ndn_DelegationSet_Delegation {
   public:

--- a/include/ndn-ind/lite/encoding/element-listener-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-listener-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/lite/encoding/element-listener-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused transports. Add readRawPackets.
+ * Summary of Changes: Remove unused transports. Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -46,7 +46,7 @@ typedef void (*OnReceivedElementLite)
  * You can use this class as is, or extend it to provide data that can be
  * accessed through the self pointer in onReceivedElement.
  */
-class ElementListenerLite : private ndn_ElementListener {
+class ndn_ind_dll ElementListenerLite : private ndn_ElementListener {
 public:
   /**
    * Create an ElementListenerLite to use the onReceivedElement function pointer.

--- a/include/ndn-ind/lite/encoding/tlv-0_1_1-wire-format-lite.hpp
+++ b/include/ndn-ind/lite/encoding/tlv-0_1_1-wire-format-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encoding/tlv-0_1_1-wire-format-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * formats are the same except that Tlv0_2WireFormatLite adds support for the
  * name component type ImplicitSha256Digest.
  */
-class Tlv0_1_1WireFormatLite : public Tlv0_2WireFormatLite {
+class ndn_ind_dll Tlv0_1_1WireFormatLite : public Tlv0_2WireFormatLite {
 };
 
 }

--- a/include/ndn-ind/lite/encoding/tlv-0_2-wire-format-lite.hpp
+++ b/include/ndn-ind/lite/encoding/tlv-0_2-wire-format-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/lite/encoding/tlv-0_2-wire-format-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused methods.
+ * Summary of Changes: Remove unused methods. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -43,7 +43,7 @@ namespace ndn {
  * NDN-TLV version 0.2. These methods call the ones for version version 0.3
  * except where the format is different for version 0.2.
  */
-class Tlv0_2WireFormatLite {
+class ndn_ind_dll Tlv0_2WireFormatLite {
 public:
   /**
    * Encode name as NDN-TLV.

--- a/include/ndn-ind/lite/encoding/tlv-0_3-wire-format-lite.hpp
+++ b/include/ndn-ind/lite/encoding/tlv-0_3-wire-format-lite.hpp
@@ -3,6 +3,18 @@
  * Copyright (C) 2020 Operant Networks, Incorporated.
  * @author: Jeff Thompson <jefft0@gmail.com>
  *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encoding/tlv-0_3-wire-format-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -38,7 +50,7 @@ namespace ndn {
  * A Tlv0_3WireFormatLite implements implement encoding and decoding using
  * NDN-TLV version 0.3.
  */
-class Tlv0_3WireFormatLite {
+class ndn_ind_dll Tlv0_3WireFormatLite {
 public:
   /**
    * Encode name as NDN-TLV.

--- a/include/ndn-ind/lite/encrypt/algo/aes-algorithm-lite.hpp
+++ b/include/ndn-ind/lite/encrypt/algo/aes-algorithm-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encrypt/algo/aes-algorithm-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * using the AES symmetric key cipher.
  * @note This class is an experimental feature. The API may change.
  */
-class AesAlgorithmLite {
+class ndn_ind_dll AesAlgorithmLite {
 public:
   /**
    * Use the key to decrypt encryptedData using AES 128 in CBC mode.

--- a/include/ndn-ind/lite/encrypt/algo/chacha20-algorithm-lite.hpp
+++ b/include/ndn-ind/lite/encrypt/algo/chacha20-algorithm-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encrypt/algo/chacha20-algorithm-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * using the ChaCha20-Poly1305 symmetric key cipher.
  * @note This class is an experimental feature. The API may change.
  */
-class ChaCha20AlgorithmLite {
+class ndn_ind_dll ChaCha20AlgorithmLite {
 public:
   /**
    * Use the key to decrypt encryptedData using ChaCha20-Poly1305.

--- a/include/ndn-ind/lite/encrypt/algo/des-algorithm-lite.hpp
+++ b/include/ndn-ind/lite/encrypt/algo/des-algorithm-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encrypt/algo/des-algorithm-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2018-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * using the DES symmetric key cipher.
  * @note This class is an experimental feature. The API may change.
  */
-class DesAlgorithmLite {
+class ndn_ind_dll DesAlgorithmLite {
 public:
   /**
    * Use the key to decrypt encryptedData using DES EDE in CBC mode with PKCS #5

--- a/include/ndn-ind/lite/encrypt/encrypted-content-lite.hpp
+++ b/include/ndn-ind/lite/encrypt/encrypted-content-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/encrypt/encrypted-content-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-group-encrypt src/encrypted-content https://github.com/named-data/ndn-group-encrypt
@@ -33,7 +45,7 @@ namespace ndn {
  * representing encrypted content.
  * @note This class is an experimental feature. The API may change.
  */
-class EncryptedContentLite : private ndn_EncryptedContent {
+class ndn_ind_dll EncryptedContentLite : private ndn_EncryptedContent {
 public:
   /**
    * Create a EncryptedContentLite with values for none.

--- a/include/ndn-ind/lite/exclude-lite.hpp
+++ b/include/ndn-ind/lite/exclude-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/exclude-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
 /**
  * An ExcludeLite holds an array of ExcludeLite::Entry.
  */
-class ExcludeLite : private ndn_Exclude {
+class ndn_ind_dll ExcludeLite : private ndn_Exclude {
 public:
   /**
    * Create an ExcludeLite with the entries array.

--- a/include/ndn-ind/lite/forwarding-flags-lite.hpp
+++ b/include/ndn-ind/lite/forwarding-flags-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/lite/forwarding-flags-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -41,7 +41,7 @@ namespace ndn {
 /**
  * @deprecated Use RegistrationOptionsLite.
  */
-class ForwardingFlagsLite : public RegistrationOptionsLite {
+class ndn_ind_dll ForwardingFlagsLite : public RegistrationOptionsLite {
 public:
   /**
    * Create a ForwardingFlagsLite with "childInherit" set and all other flags

--- a/include/ndn-ind/lite/interest-lite.hpp
+++ b/include/ndn-ind/lite/interest-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/interest-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
 /**
  * An InterestLite holds a NameLite and other fields for an interest.
  */
-class InterestLite : private ndn_Interest {
+class ndn_ind_dll InterestLite : private ndn_Interest {
 public:
   /**
    * Create an InterestLite with the pre-allocated nameComponents and

--- a/include/ndn-ind/lite/key-locator-lite.hpp
+++ b/include/ndn-ind/lite/key-locator-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/key-locator-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
  * A KeyLocatorLite holds a type and other info to represent the key which signs
  * a Data packet.
  */
-class KeyLocatorLite : private ndn_KeyLocator {
+class ndn_ind_dll KeyLocatorLite : private ndn_KeyLocator {
 public:
   /**
    * Create a KeyLocatorLite with the pre-allocated nameComponents, and defaults

--- a/include/ndn-ind/lite/lp/congestion-mark-lite.hpp
+++ b/include/ndn-ind/lite/lp/congestion-mark-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/lp/congestion-mark-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2018-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ class LpPacketLite;
  * packet.
  * http://redmine.named-data.net/projects/nfd/wiki/NDNLPv2
  */
-class CongestionMarkLite : private ndn_CongestionMark {
+class ndn_ind_dll CongestionMarkLite : private ndn_CongestionMark {
 public:
   /**
    * Create a CongestionMarkLite where all the values are unspecified.

--- a/include/ndn-ind/lite/lp/incoming-face-id-lite.hpp
+++ b/include/ndn-ind/lite/lp/incoming-face-id-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/lp/incoming-face-id-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx fields.hpp https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/lp/fields.hpp
@@ -34,7 +46,7 @@ class LpPacketLite;
  * packet.
  * http://redmine.named-data.net/projects/nfd/wiki/NDNLPv2
  */
-class IncomingFaceIdLite : private ndn_IncomingFaceId {
+class ndn_ind_dll IncomingFaceIdLite : private ndn_IncomingFaceId {
 public:
   /**
    * Create a IncomingFaceIdLite where all the values are unspecified.

--- a/include/ndn-ind/lite/lp/lp-packet-lite.hpp
+++ b/include/ndn-ind/lite/lp/lp-packet-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/lp/lp-packet-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx packet.hpp https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/lp/packet.hpp
@@ -31,7 +43,7 @@
 
 namespace ndn {
 
-class LpPacketHeaderFieldLite : private ndn_LpPacketHeaderField {
+class ndn_ind_dll LpPacketHeaderFieldLite : private ndn_LpPacketHeaderField {
 public:
   /**
    * Get the type of this header field.

--- a/include/ndn-ind/lite/meta-info-lite.hpp
+++ b/include/ndn-ind/lite/meta-info-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/meta-info-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
  * A MetaInfoLite holds a type and other info to represent the meta info of a
  * Data packet.
  */
-class MetaInfoLite : private ndn_MetaInfo {
+class ndn_ind_dll MetaInfoLite : private ndn_MetaInfo {
 public:
   /**
    * Create a MetaInfoLite with default field values.

--- a/include/ndn-ind/lite/name-lite.hpp
+++ b/include/ndn-ind/lite/name-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/name-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ class ExcludeLite;
 /**
  * A NameLite holds an array of NameLite::Component.
  */
-class NameLite : public ndn_Name {
+class ndn_ind_dll NameLite : public ndn_Name {
 public:
   /**
    * A NameLite::Component holds a pointer to the component value.

--- a/include/ndn-ind/lite/network-nack-lite.hpp
+++ b/include/ndn-ind/lite/network-nack-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/network-nack-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx nack.hpp https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/lp/nack.hpp
@@ -32,7 +44,7 @@ class LpPacketLite;
 /**
  * NetworkNackLite represents a network Nack packet and includes a Nack reason.
  */
-class NetworkNackLite : private ndn_NetworkNack {
+class ndn_ind_dll NetworkNackLite : private ndn_NetworkNack {
 public:
   /**
    * Create a NetworkNackLite where all the values are unspecified.

--- a/include/ndn-ind/lite/registration-options-lite.hpp
+++ b/include/ndn-ind/lite/registration-options-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/registration-options-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2019-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -22,6 +34,7 @@
 #ifndef NDN_REGISTRATION_OPTIONS_LITE_HPP
 #define NDN_REGISTRATION_OPTIONS_LITE_HPP
 
+#include "../c/common.h"
 #include "../c/registration-options-types.h"
 
 namespace ndn {
@@ -33,7 +46,7 @@ namespace ndn {
  * format of the registration command is changed.
  * (This class was renamed from ForwardingFlagsLite, which is deprecated.)
  */
-class RegistrationOptionsLite : protected ndn_RegistrationOptions {
+class ndn_ind_dll RegistrationOptionsLite : protected ndn_RegistrationOptions {
 public:
   /**
    * Create a RegistrationOptionsLite with "childInherit" set and all other flags

--- a/include/ndn-ind/lite/security/ec-private-key-lite.hpp
+++ b/include/ndn-ind/lite/security/ec-private-key-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/security/ec-private-key-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * An EcPrivateKeyLite holds a decoded or generated EC private key for use in
  * crypto operations.
  */
-class EcPrivateKeyLite : public ndn_EcPrivateKey {
+class ndn_ind_dll EcPrivateKeyLite : public ndn_EcPrivateKey {
 public:
   /**
    * Create an EcPrivateKeyLite with a null value.

--- a/include/ndn-ind/lite/security/ec-public-key-lite.hpp
+++ b/include/ndn-ind/lite/security/ec-public-key-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/security/ec-public-key-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -31,7 +43,7 @@ namespace ndn {
 /**
  * An EcPublicKeyLite holds a decoded EC public key for use in crypto operations.
  */
-class EcPublicKeyLite : private ndn_EcPublicKey {
+class ndn_ind_dll EcPublicKeyLite : private ndn_EcPublicKey {
 public:
   /**
    * Create an EcPublicKeyLite with a null value.

--- a/include/ndn-ind/lite/security/rsa-private-key-lite.hpp
+++ b/include/ndn-ind/lite/security/rsa-private-key-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/security/rsa-private-key-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * An RsaPrivateKeyLite holds a decoded or generated RSA private key for use in
  * crypto operations.
  */
-class RsaPrivateKeyLite : private ndn_RsaPrivateKey {
+class ndn_ind_dll RsaPrivateKeyLite : private ndn_RsaPrivateKey {
 public:
   /**
    * Create an RsaPrivateKeyLite with a null value.

--- a/include/ndn-ind/lite/security/rsa-public-key-lite.hpp
+++ b/include/ndn-ind/lite/security/rsa-public-key-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/security/rsa-public-key-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * An RsaPublicKeyLite holds a decoded RSA public key for use in crypto
  * operations.
  */
-class RsaPublicKeyLite : private ndn_RsaPublicKey {
+class ndn_ind_dll RsaPublicKeyLite : private ndn_RsaPublicKey {
 public:
   /**
    * Create an RsaPublicKeyLite with a null value.

--- a/include/ndn-ind/lite/security/validity-period-lite.hpp
+++ b/include/ndn-ind/lite/security/validity-period-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/security/validity-period-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
  * A ValidityPeriodLite is used in a Data packet's SignatureInfo and represents
  * the begin and end times of a certificate's validity period.
  */
-class ValidityPeriodLite : private ndn_ValidityPeriod {
+class ndn_ind_dll ValidityPeriodLite : private ndn_ValidityPeriod {
 public:
   /**
    * Create a default ValidityPeriodLite where the period is not specified.

--- a/include/ndn-ind/lite/signature-lite.hpp
+++ b/include/ndn-ind/lite/signature-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/signature-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -34,7 +46,7 @@ namespace ndn {
  * This has the union of fields needed to represent specific types of signature
  * such as Sha256WithRsaSignature and DigestSha256Signature.
  */
-class SignatureLite : private ndn_Signature {
+class ndn_ind_dll SignatureLite : private ndn_Signature {
 public:
   /**
    * Create a SignatureLite with values for none.

--- a/include/ndn-ind/lite/transport/tcp-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/tcp-transport-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/lite/transport/tcp-transport-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -45,7 +45,7 @@ namespace ndn {
  * A TcpTransportLite object is used to send packets and to listen for incoming
  * packets over a TCP socket. See connect() and processEvents() for more details.
  */
-class TcpTransportLite : private ndn_TcpTransport {
+class ndn_ind_dll TcpTransportLite : private ndn_TcpTransport {
 public:
   /**
    * Create a TcpTransport with default values for no connection yet and to use

--- a/include/ndn-ind/lite/transport/udp-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/udp-transport-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/lite/transport/udp-transport-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -45,7 +45,7 @@ namespace ndn {
  * A UdpTransportLite object is used to send packets and to listen for incoming
  * packets over a UDP socket. See connect() and processEvents() for more details.
  */
-class UdpTransportLite : private ndn_UdpTransport {
+class ndn_ind_dll UdpTransportLite : private ndn_UdpTransport {
 public:
   /**
    * Create a UdpTransport with default values for no connection yet and to use

--- a/include/ndn-ind/lite/transport/unix-transport-lite.hpp
+++ b/include/ndn-ind/lite/transport/unix-transport-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/lite/transport/unix-transport-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -46,7 +46,7 @@ namespace ndn {
  * packets over a Unix socket. See connect() and processEvents() for more
  * details.
  */
-class UnixTransportLite : private ndn_UnixTransport {
+class ndn_ind_dll UnixTransportLite : private ndn_UnixTransport {
 public:
   /**
    * Create a UnixTransport with default values for no connection yet and to use

--- a/include/ndn-ind/lite/util/blob-lite.hpp
+++ b/include/ndn-ind/lite/util/blob-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/util/blob-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -34,7 +46,7 @@ namespace ndn {
  * to change the pointer, and so this does allow the copy constructor and
  * assignment to change the pointer.  Also remember that the pointer can be null.
  */
-class BlobLite : private ndn_Blob {
+class ndn_ind_dll BlobLite : private ndn_Blob {
 public:
   /**
    * Create a BlobLite where the buf and size are 0.

--- a/include/ndn-ind/lite/util/crypto-lite.hpp
+++ b/include/ndn-ind/lite/util/crypto-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/util/crypto-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -30,7 +42,7 @@ namespace ndn {
 /**
  * CryptoLite has static methods for basic cryptography operations.
  */
-class CryptoLite {
+class ndn_ind_dll CryptoLite {
 public:
   /**
    * Compute the sha-256 digest of data.

--- a/include/ndn-ind/lite/util/dynamic-malloc-uint8-array-lite.hpp
+++ b/include/ndn-ind/lite/util/dynamic-malloc-uint8-array-lite.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lite/util/dynamic-malloc-uint8-array-lite.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -35,7 +47,7 @@ namespace ndn {
  * If your lightweight platform doesn't support malloc then don't link to this
  * file, and use DynamicUInt8ArrayLite directly with a fixed-size array.
  */
-class DynamicMallocUInt8ArrayLite : public DynamicUInt8ArrayLite {
+class ndn_ind_dll DynamicMallocUInt8ArrayLite : public DynamicUInt8ArrayLite {
 public:
   /**
    * Create a DynamicMallocUInt8ArrayLite with a buffer of the initial length.

--- a/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
+++ b/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/lite/util/dynamic-uint8-array-lite.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Remove unused transports.
+ * Summary of Changes: Remove unused transports. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -44,7 +44,7 @@ namespace ndn {
  * the allocated array, and an optional realloc function which can changes its
  * size.
  */
-class DynamicUInt8ArrayLite : private ndn_DynamicUInt8Array {
+class ndn_ind_dll DynamicUInt8ArrayLite : private ndn_DynamicUInt8Array {
 public:
   /**
    * Create a DynamicUInt8ArrayLite with the given array buffer.

--- a/include/ndn-ind/lp-packet-header-field.hpp
+++ b/include/ndn-ind/lp-packet-header-field.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/lp-packet-header-field.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -28,7 +40,7 @@ namespace ndn {
  * This is a base class for LP packet header fields like NetworkNack. The
  * application does not use it directly.
  */
-class LpPacketHeaderField {
+class ndn_ind_dll LpPacketHeaderField {
 public:
   /**
    * The virtual destructor for the base class.

--- a/include/ndn-ind/meta-info.hpp
+++ b/include/ndn-ind/meta-info.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/meta-info.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Use std::chrono.
+ * Summary of Changes: Use NDN_IND macros. Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -44,7 +44,7 @@ namespace ndn {
 /**
  * A MetaInfo holds the meta info which is signed inside the data packet.
  */
-class MetaInfo {
+class ndn_ind_dll MetaInfo {
 public:
   MetaInfo()
   : timestamp_(std::chrono::milliseconds(-1)), changeCount_(0)

--- a/include/ndn-ind/name.hpp
+++ b/include/ndn-ind/name.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cpp
  *
  * Summary of Changes: Use NDN_IND macros. Use std::chrono. Add findParametersSha256Digest.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -49,12 +50,12 @@ namespace ndn {
 /**
  * A Name holds an array of Name::Component and represents an NDN name.
  */
-class Name {
+class ndn_ind_dll Name {
 public:
   /**
    * A Name::Component holds a read-only name component value.
    */
-  class Component {
+  class ndn_ind_dll Component {
   public:
     /**
      * Create a new GENERIC Name::Component with a zero-length value.

--- a/include/ndn-ind/network-nack.hpp
+++ b/include/ndn-ind/network-nack.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/network-nack.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2016-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx nack.hpp https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/lp/nack.hpp
@@ -32,7 +44,7 @@ namespace ndn {
 
 class LpPacket;
 
-class NetworkNack : public LpPacketHeaderField {
+class ndn_ind_dll NetworkNack : public LpPacketHeaderField {
 public:
   /**
    * Create an NetworkNack where all the values are unspecified.

--- a/include/ndn-ind/registration-options.hpp
+++ b/include/ndn-ind/registration-options.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/registration-options.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2019-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * format of the registration command is changed.
  * (This class was renamed from ForwardingFlags, which is deprecated.)
  */
-class RegistrationOptions {
+class ndn_ind_dll RegistrationOptions {
 public:
   /**
    * Create a new RegistrationOptions with "childInherit" set and all other

--- a/include/ndn-ind/security/certificate/certificate-extension.hpp
+++ b/include/ndn-ind/security/certificate/certificate-extension.hpp
@@ -34,7 +34,7 @@ class DerNode;
 /**
  * A CertificateExtension represents the Extension entry in a certificate.
  */
-class CertificateExtension
+class ndn_ind_dll CertificateExtension
 {
 public:
   /**

--- a/include/ndn-ind/security/certificate/certificate-subject-description.hpp
+++ b/include/ndn-ind/security/certificate/certificate-subject-description.hpp
@@ -33,7 +33,7 @@ class DerNode;
 /**
  * A CertificateSubjectDescription represents the SubjectDescription entry in a Certificate.
  */
-class CertificateSubjectDescription {
+class ndn_ind_dll CertificateSubjectDescription {
 public:
   /**
    * Create a new CertificateSubjectDescription.

--- a/include/ndn-ind/security/certificate/certificate.hpp
+++ b/include/ndn-ind/security/certificate/certificate.hpp
@@ -48,7 +48,7 @@ namespace ndn {
 typedef std::vector<CertificateSubjectDescription> SubjectDescriptionList;
 typedef std::vector<CertificateExtension> ExtensionList;
 
-class Certificate : public Data {
+class ndn_ind_dll Certificate : public Data {
 public:
   /**
    * The default constructor.

--- a/include/ndn-ind/security/certificate/public-key.hpp
+++ b/include/ndn-ind/security/certificate/public-key.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/certificate/public-key.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Yingdi Yu <yingdi@cs.ucla.edu>
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
@@ -31,7 +43,7 @@ namespace ndn {
 
 class DerNode;
 
-class PublicKey {
+class ndn_ind_dll PublicKey {
 public:
   /**
    * The default constructor.

--- a/include/ndn-ind/security/command-interest-preparer.hpp
+++ b/include/ndn-ind/security/command-interest-preparer.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/command-interest-preparer.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ namespace ndn {
  * documentation:
  * https://redmine.named-data.net/projects/ndn-cxx/wiki/CommandInterest
  */
-class CommandInterestPreparer {
+class ndn_ind_dll CommandInterestPreparer {
 public:
   /**
    * Create a CommandInterestPreparer and initialize the timestamp to now.

--- a/include/ndn-ind/security/command-interest-signer.hpp
+++ b/include/ndn-ind/security/command-interest-signer.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/command-interest-signer.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2018-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/command-interest-signer.hpp
@@ -35,7 +47,7 @@ namespace ndn {
  * See makeCommandInterest() for details.
  * https://redmine.named-data.net/projects/ndn-cxx/wiki/CommandInterest
  */
-class CommandInterestSigner : public CommandInterestPreparer {
+class ndn_ind_dll CommandInterestSigner : public CommandInterestPreparer {
 public:
   /**
    * Create a CommandInterestSigner to use the keyChain to sign.

--- a/include/ndn-ind/security/key-chain.hpp
+++ b/include/ndn-ind/security/key-chain.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/key-chain.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Remove unused methods from security v1.
+ * Summary of Changes: Use NDN_IND macros. Remove unused methods from security v1. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -59,7 +59,7 @@ class ConfigFile;
  * @note This class is an experimental feature.  See the API docs for more detail at
  * http://named-data.net/doc/ndn-ccl-api/key-chain.html .
  */
-class KeyChain {
+class ndn_ind_dll KeyChain {
 public:
   /**
    * A KeyChain::Error extends runtime_error and represents an error in KeyChain

--- a/include/ndn-ind/security/key-params.hpp
+++ b/include/ndn-ind/security/key-params.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/key-params.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2015-2020 Regents of the University of California.
  * @author: Yingdi Yu <yingdi@cs.ucla.edu>
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
@@ -33,7 +45,7 @@ namespace ndn {
  * KeyParams is a base class for key parameters. Its subclasses are used to
  * store parameters for key generation.
  */
-class KeyParams {
+class ndn_ind_dll KeyParams {
 public:
   virtual
   ~KeyParams()
@@ -77,7 +89,7 @@ private:
   Name::Component keyId_;
 };
 
-class RsaKeyParams : public KeyParams {
+class ndn_ind_dll RsaKeyParams : public KeyParams {
 public:
   RsaKeyParams
     (const Name::Component& keyId,
@@ -111,7 +123,7 @@ private:
   uint32_t size_;
 };
 
-class EcKeyParams : public KeyParams {
+class ndn_ind_dll EcKeyParams : public KeyParams {
 public:
   EcKeyParams
     (const Name::Component& keyId,
@@ -149,7 +161,7 @@ private:
 /**
  * @deprecated Use EcKeyParams
  */
-class EcdsaKeyParams : public EcKeyParams {
+class ndn_ind_dll EcdsaKeyParams : public EcKeyParams {
 public:
   EcdsaKeyParams
     (const Name::Component& keyId,
@@ -166,7 +178,7 @@ public:
   }
 };
 
-class AesKeyParams : public KeyParams {
+class ndn_ind_dll AesKeyParams : public KeyParams {
 public:
   AesKeyParams
     (const Name::Component& keyId,

--- a/include/ndn-ind/security/pib/pib-certificate-container.hpp
+++ b/include/ndn-ind/security/pib/pib-certificate-container.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-certificate-container.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/certificate-container.hpp
@@ -41,7 +53,7 @@ class PibKey;
  * A PibCertificateContainer is used to search/enumerate the certificates of a
  * key. (A PibCertificateContainer object can only be created by PibKey.)
  */
-class PibCertificateContainer {
+class ndn_ind_dll PibCertificateContainer {
 public:
   /**
    * Get the number of certificates in the container.

--- a/include/ndn-ind/security/pib/pib-identity-container.hpp
+++ b/include/ndn-ind/security/pib/pib-identity-container.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-identity-container.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/identity-container.hpp
@@ -41,7 +53,7 @@ class PibIdentityImpl;
  * A PibIdentityContainer is used to search/enumerate the identities in a PIB.
  * (A PibIdentityContainer object can only be created by the Pib class.)
  */
-class PibIdentityContainer {
+class ndn_ind_dll PibIdentityContainer {
 public:
   /**
    * Get the number of identities in the container.

--- a/include/ndn-ind/security/pib/pib-identity.hpp
+++ b/include/ndn-ind/security/pib/pib-identity.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-identity.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/identity.hpp
@@ -45,7 +57,7 @@ class PibIdentityImpl;
  * is set as the default key of this identity.  Properties of a key can be
  * accessed after obtaining a PibKey object.
  */
-class PibIdentity {
+class ndn_ind_dll PibIdentity {
 public:
   /*
    * Get the name of the identity.

--- a/include/ndn-ind/security/pib/pib-impl.hpp
+++ b/include/ndn-ind/security/pib/pib-impl.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-impl.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/pib-impl.hpp
@@ -35,7 +47,7 @@ namespace ndn {
  * class. This class defines the interface that an actual PIB implementation
  * should provide, for example PibMemory.
  */
-class PibImpl {
+class ndn_ind_dll PibImpl {
 public:
   /**
    * A PibImpl::Error extends runtime_error and represents a non-semantic error

--- a/include/ndn-ind/security/pib/pib-key-container.hpp
+++ b/include/ndn-ind/security/pib/pib-key-container.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-key-container.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/key-container.hpp
@@ -39,7 +51,7 @@ class PibKeyImpl;
  * A PibKeyContainer is used to search/enumerate the keys of an identity.
  * (A PibKeyContainer object can only be created by PibIdentity.)
  */
-class PibKeyContainer {
+class ndn_ind_dll PibKeyContainer {
 public:
   /**
    * Get the number of keys in the container.

--- a/include/ndn-ind/security/pib/pib-key.hpp
+++ b/include/ndn-ind/security/pib/pib-key.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-key.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/key.hpp
@@ -40,7 +52,7 @@ class PibKeyImpl;
  * objects, one of which is set as the default certificate of this key.
  * A certificate can be directly accessed by getting a CertificateV2 object.
  */
-class PibKey {
+class ndn_ind_dll PibKey {
 public:
   /*
    * Get the key name.

--- a/include/ndn-ind/security/pib/pib-memory.hpp
+++ b/include/ndn-ind/security/pib/pib-memory.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib-memory.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/pib-memory.hpp
@@ -33,7 +45,7 @@ namespace ndn {
  * implementation of a PIB. All the contents in the PIB are stored in memory and
  * have the same lifetime as the PibMemory instance.
  */
-class PibMemory : public PibImpl {
+class ndn_ind_dll PibMemory : public PibImpl {
 public:
   /**
    * Create a default PibMemory with no values.

--- a/include/ndn-ind/security/pib/pib-sqlite3.hpp
+++ b/include/ndn-ind/security/pib/pib-sqlite3.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/pib/pib-sqlite3.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -54,7 +54,7 @@ namespace ndn {
  * in an SQLite3 database file. This provides more persistent storage than
  * PibMemory.
  */
-class PibSqlite3 : public PibImpl {
+class ndn_ind_dll PibSqlite3 : public PibImpl {
 public:
   /**
    * Create a new PibSqlite3 to work with an SQLite3 file. This assumes that the

--- a/include/ndn-ind/security/pib/pib.hpp
+++ b/include/ndn-ind/security/pib/pib.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/pib/pib.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/pib/pib.hpp
@@ -51,7 +63,7 @@ class PibImpl;
  * Note: A Pib instance is created and managed only by the KeyChain, and is
  * returned by the KeyChain getPib() method.
  */
-class Pib {
+class ndn_ind_dll Pib {
 public:
   /**
    * A Pib::Error extends runtime_error and represents a semantic error in PIB

--- a/include/ndn-ind/security/safe-bag.hpp
+++ b/include/ndn-ind/security/safe-bag.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/safe-bag.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/safe-bag.hpp
@@ -34,7 +46,7 @@ class TlvEncoder;
  * A SafeBag represents a container for sensitive related information such as a
  * certificate and private key.
  */
-class SafeBag {
+class ndn_ind_dll SafeBag {
 public:
   /**
    * Create a SafeBag with the given certificate and private key.

--- a/include/ndn-ind/security/security-exception.hpp
+++ b/include/ndn-ind/security/security-exception.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/security-exception.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Yingdi Yu <yingdi@cs.ucla.edu>
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
@@ -23,12 +35,13 @@
 #ifndef NDN_SECURITY_EXCEPTION_HPP
 #define NDN_SECURITY_EXCEPTION_HPP
 
+#include "../c/common.h"
 #include <exception>
 #include <string>
 
 namespace ndn {
 
-class SecurityException : public std::exception {
+class ndn_ind_dll SecurityException : public std::exception {
 public:
   SecurityException(const std::string& errorMessage) throw();
 
@@ -44,7 +57,7 @@ private:
   const std::string errorMessage_;
 };
 
-class UnrecognizedKeyFormatException : public SecurityException {
+class ndn_ind_dll UnrecognizedKeyFormatException : public SecurityException {
 public:
   UnrecognizedKeyFormatException(const std::string& errorMessage)
   : SecurityException(errorMessage)
@@ -52,7 +65,7 @@ public:
   }
 };
 
-class UnrecognizedDigestAlgorithmException : public SecurityException {
+class ndn_ind_dll UnrecognizedDigestAlgorithmException : public SecurityException {
 public:
   UnrecognizedDigestAlgorithmException(const std::string& errorMessage)
   : SecurityException(errorMessage)

--- a/include/ndn-ind/security/signing-info.hpp
+++ b/include/ndn-ind/security/signing-info.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/signing-info.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/signing-info.hpp
@@ -36,7 +48,7 @@ namespace ndn {
  * SigningInfo is invalid if the specified identity/key/certificate does not
  * exist, or the PibIdentity or PibKey instance is not valid.
  */
-class SigningInfo {
+class ndn_ind_dll SigningInfo {
 public:
   enum SignerType {
     /** No signer is specified. Use default settings or follow the trust schema. */

--- a/include/ndn-ind/security/tpm/helper-osx.hpp
+++ b/include/ndn-ind/security/tpm/helper-osx.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/tpm/helper-osx.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -42,6 +42,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
 #include <CoreServices/CoreServices.h>
+#include "../../c/common.h"
 
 namespace ndn {
 
@@ -55,7 +56,7 @@ namespace ndn {
  * http://www.cocoabuilder.com/archive/cocoa/130776-auto-cfrelease-and.html
  */
 template<class T>
-class CFReleaser
+class ndn_ind_dll CFReleaser
 {
 public:
   //////////////////////////////

--- a/include/ndn-ind/security/tpm/tpm-back-end-file.hpp
+++ b/include/ndn-ind/security/tpm/tpm-back-end-file.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-back-end-file.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/back-end-file.hpp
@@ -35,7 +47,7 @@ class TpmPrivateKey;
  * file with permission 0400, i.e., owner read-only.  The key is stored in
  * PKCS #1 format in base64 encoding.
  */
-class TpmBackEndFile : public TpmBackEnd {
+class ndn_ind_dll TpmBackEndFile : public TpmBackEnd {
 public:
   /**
    * A TpmBackEndFile::Error extends TpmBackEnd::Error and represents a

--- a/include/ndn-ind/security/tpm/tpm-back-end-memory.hpp
+++ b/include/ndn-ind/security/tpm/tpm-back-end-memory.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-back-end-memory.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/back-end-mem.hpp
@@ -34,7 +46,7 @@ class TpmPrivateKey;
  * TpmBackEndMemory extends TpmBackEnd to implement a TPM back-end using
  * in-memory storage.
  */
-class TpmBackEndMemory : public TpmBackEnd {
+class ndn_ind_dll TpmBackEndMemory : public TpmBackEnd {
 public:
   TpmBackEndMemory();
 

--- a/include/ndn-ind/security/tpm/tpm-back-end-osx.hpp
+++ b/include/ndn-ind/security/tpm/tpm-back-end-osx.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/tpm/tpm-back-end-osx.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ namespace ndn {
  * TpmBackEndOsx extends TpmBackEnd to implement a TPM back-end using the macOS
  * Keychain services.
  */
-class TpmBackEndOsx : public TpmBackEnd {
+class ndn_ind_dll TpmBackEndOsx : public TpmBackEnd {
 public:
   /**
    * A TpmBackEndOsx::Error extends TpmBackEnd::Error and represents a

--- a/include/ndn-ind/security/tpm/tpm-back-end.hpp
+++ b/include/ndn-ind/security/tpm/tpm-back-end.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-back-end.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/back-end.hpp
@@ -37,7 +49,7 @@ class TpmKeyHandle;
  * interface that an actual TPM backend implementation should provide, for
  * example TpmBackEndMemory.
  */
-class TpmBackEnd {
+class ndn_ind_dll TpmBackEnd {
 public:
   /**
    * A TpmBackEnd::Error extends runtime_error and represents a non-semantic

--- a/include/ndn-ind/security/tpm/tpm-key-handle-memory.hpp
+++ b/include/ndn-ind/security/tpm/tpm-key-handle-memory.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-key-handle-memory.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/key-handle-mem.hpp
@@ -33,7 +45,7 @@ class TpmPrivateKey;
  * TpmKeyHandleMemory extends TpmKeyHandle to implement a TPM key handle that
  * keeps the private key in memory.
  */
-class TpmKeyHandleMemory : public TpmKeyHandle
+class ndn_ind_dll TpmKeyHandleMemory : public TpmKeyHandle
 {
 public:
   /**

--- a/include/ndn-ind/security/tpm/tpm-key-handle-osx.hpp
+++ b/include/ndn-ind/security/tpm/tpm-key-handle-osx.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/tpm/tpm-key-handle-osx.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ namespace ndn {
  * TpmKeyHandleMemory extends TpmKeyHandle to implement a TPM key handle that
  * uses the macOS Keychain services.
  */
-class TpmKeyHandleOsx : public TpmKeyHandle
+class ndn_ind_dll TpmKeyHandleOsx : public TpmKeyHandle
 {
 public:
   TpmKeyHandleOsx(const KeyRefOsx& key);

--- a/include/ndn-ind/security/tpm/tpm-key-handle.hpp
+++ b/include/ndn-ind/security/tpm/tpm-key-handle.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-key-handle.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/key-handle.hpp
@@ -32,7 +44,7 @@ namespace ndn {
  * TpmKeyHandle is an abstract base class for a TPM key handle, which provides
  * an interface to perform cryptographic operations with a key in the TPM.
  */
-class TpmKeyHandle {
+class ndn_ind_dll TpmKeyHandle {
 public:
   virtual
   ~TpmKeyHandle();

--- a/include/ndn-ind/security/tpm/tpm-private-key.hpp
+++ b/include/ndn-ind/security/tpm/tpm-private-key.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm-private-key.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/transform/private-key.hpp
@@ -41,7 +53,7 @@ class DerNode;
  * A TpmPrivateKey holds an in-memory private key and provides cryptographic
  * operations such as for signing by the in-memory TPM.
  */
-class TpmPrivateKey {
+class ndn_ind_dll TpmPrivateKey {
 public:
   /**
    * A TpmPrivateKey::Error extends runtime_error and represents an error in

--- a/include/ndn-ind/security/tpm/tpm.hpp
+++ b/include/ndn-ind/security/tpm/tpm.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/tpm/tpm.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/tpm/tpm.hpp
@@ -52,7 +64,7 @@ class TpmBackEnd;
  * check for the existence of private keys, get public keys for the private
  * keys, sign, and decrypt the supplied buffers using managed private keys.
  */
-class Tpm {
+class ndn_ind_dll Tpm {
 public:
   /**
    * A Tpm::Error extends runtime_error and represents a semantic error in TPM

--- a/include/ndn-ind/security/v2/certificate-cache-v2.hpp
+++ b/include/ndn-ind/security/v2/certificate-cache-v2.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/certificate-cache-v2.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -47,7 +47,7 @@ namespace ndn {
  * format CertificateV2. A certificate is removed no later than its NotAfter
  * time, or maxLifetime after it has been added to the cache.
  */
-class CertificateCacheV2 {
+class ndn_ind_dll CertificateCacheV2 {
 public:
   /**
    * Create a CertificateCacheV2.

--- a/include/ndn-ind/security/v2/certificate-fetcher-from-network.hpp
+++ b/include/ndn-ind/security/v2/certificate-fetcher-from-network.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/certificate-fetcher-from-network.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/certificate-fetcher-from-network.hpp
@@ -32,7 +44,7 @@ namespace ndn {
  * CertificateFetcherFromNetwork extends CertificateFetcher to fetch missing
  * certificates from the network.
  */
-class CertificateFetcherFromNetwork : public CertificateFetcher {
+class ndn_ind_dll CertificateFetcherFromNetwork : public CertificateFetcher {
 public:
   /**
    * Create a CertificateFetcherFromNetwork to fetch certificates using the Face.

--- a/include/ndn-ind/security/v2/certificate-fetcher-offline.hpp
+++ b/include/ndn-ind/security/v2/certificate-fetcher-offline.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/certificate-fetcher-offline.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/certificate-fetcher-offline.hpp
@@ -30,7 +42,7 @@ namespace ndn {
  * CertificateFetcherOffline extends CertificateFetcher to implement a fetcher
  * that does not fetch certificates (always offline).
  */
-class CertificateFetcherOffline : public CertificateFetcher {
+class ndn_ind_dll CertificateFetcherOffline : public CertificateFetcher {
 protected:
   virtual void
   doFetch

--- a/include/ndn-ind/security/v2/certificate-fetcher.hpp
+++ b/include/ndn-ind/security/v2/certificate-fetcher.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/certificate-fetcher.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/certificate-fetcher.hpp
@@ -33,7 +45,7 @@ namespace ndn {
  * CertificateFetcher is an abstract base class which provides an interface used
  * by the validator to fetch missing certificates.
  */
-class CertificateFetcher {
+class ndn_ind_dll CertificateFetcher {
 public:
   typedef func_lib::function<void
     (const ptr_lib::shared_ptr<CertificateV2>& certificate,

--- a/include/ndn-ind/security/v2/certificate-request.hpp
+++ b/include/ndn-ind/security/v2/certificate-request.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/certificate-request.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/certificate-request.hpp
@@ -32,7 +44,7 @@ namespace ndn {
  * the number of retries left. The interest_ and nRetriesLeft_ fields are
  * public so that you can modify them.
  */
-class CertificateRequest {
+class ndn_ind_dll CertificateRequest {
 public:
   /**
    * Create a CertificateRequest with a default Interest and 0 retries left.

--- a/include/ndn-ind/security/v2/certificate-storage.hpp
+++ b/include/ndn-ind/security/v2/certificate-storage.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/certificate-storage.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -44,7 +44,7 @@ namespace ndn {
  * The CertificateStorage class stores trusted anchors and has a verified
  * certificate cache, and an unverified certificate cache.
  */
-class CertificateStorage {
+class ndn_ind_dll CertificateStorage {
 public:
   CertificateStorage()
   : verifiedCertificateCache_(std::chrono::hours(1)),

--- a/include/ndn-ind/security/v2/certificate-v2.hpp
+++ b/include/ndn-ind/security/v2/certificate-v2.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/certificate-v2.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -91,7 +91,7 @@ namespace ndn {
  *
  * @see https://github.com/named-data/ndn-cxx/blob/master/docs/specs/certificate-format.rst
  */
-class CertificateV2 : public Data {
+class ndn_ind_dll CertificateV2 : public Data {
 public:
   /**
    * A CertificateV2::Error extends runtime_error and represents errors for not

--- a/include/ndn-ind/security/v2/trust-anchor-container.hpp
+++ b/include/ndn-ind/security/v2/trust-anchor-container.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/trust-anchor-container.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -59,7 +59,7 @@ namespace ndn {
  * be valid until the next invocation of `find` and may be invalidated
  * afterwards.
  */
-class TrustAnchorContainer {
+class ndn_ind_dll TrustAnchorContainer {
 public:
   class Error : public std::runtime_error
   {

--- a/include/ndn-ind/security/v2/trust-anchor-group.hpp
+++ b/include/ndn-ind/security/v2/trust-anchor-group.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/trust-anchor-group.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -40,7 +40,7 @@
 
 namespace ndn {
 
-class CertificateContainerInterface
+class ndn_ind_dll CertificateContainerInterface
 {
 public:
   virtual
@@ -66,7 +66,7 @@ public:
  * TrustAnchorGroup represents a group of trust anchors which implement the
  * CertificateContainerInterface.
  */
-class TrustAnchorGroup
+class ndn_ind_dll TrustAnchorGroup
 {
 public:
   /**
@@ -128,7 +128,7 @@ private:
  * The StaticTrustAnchorGroup class extends TrustAnchorGroup to implement a
  * static trust anchor group.
  */
-class StaticTrustAnchorGroup : public TrustAnchorGroup {
+class ndn_ind_dll StaticTrustAnchorGroup : public TrustAnchorGroup {
 public:
   StaticTrustAnchorGroup
     (CertificateContainerInterface& certificateContainer, const std::string& id)
@@ -156,7 +156,7 @@ public:
  * The DynamicTrustAnchorGroup class extends TrustAnchorGroup to implement a
  * dynamic trust anchor group.
  */
-class DynamicTrustAnchorGroup : public TrustAnchorGroup {
+class ndn_ind_dll DynamicTrustAnchorGroup : public TrustAnchorGroup {
 public:
   /**
    * Create a dynamic trust anchor group.

--- a/include/ndn-ind/security/v2/validation-error.hpp
+++ b/include/ndn-ind/security/v2/validation-error.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-error.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validation-error.hpp
@@ -31,7 +43,7 @@ namespace ndn {
 /**
  * A ValidationError holds an error code and an optional detailed error message.
  */
-class ValidationError {
+class ndn_ind_dll ValidationError {
 public:
   static const int NO_ERROR =                    0;
   static const int INVALID_SIGNATURE =           1;
@@ -85,7 +97,7 @@ private:
   std::string info_;
 };
 
-std::ostream&
+ndn_ind_dll std::ostream&
 operator<<(std::ostream& os, const ValidationError& error);
 
 }

--- a/include/ndn-ind/security/v2/validation-policy-accept-all.hpp
+++ b/include/ndn-ind/security/v2/validation-policy-accept-all.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-policy-accept-all.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validation-policy-accept-all.hpp
@@ -31,7 +43,7 @@ namespace ndn {
  * ValidationPolicyAcceptAll extends ValidationPolicy to implement a validator
  * policy that accepts any signature of a Data or Interest packet.
  */
-class ValidationPolicyAcceptAll : public ValidationPolicy {
+class ndn_ind_dll ValidationPolicyAcceptAll : public ValidationPolicy {
 public:
   virtual void
   checkPolicy

--- a/include/ndn-ind/security/v2/validation-policy-command-interest.hpp
+++ b/include/ndn-ind/security/v2/validation-policy-command-interest.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/validation-policy-command-interest.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -49,7 +49,7 @@ namespace ndn {
  * Signed Interest validation and Data validation requests are delegated to an
  * inner policy.
  */
-class ValidationPolicyCommandInterest : public ValidationPolicy
+class ndn_ind_dll ValidationPolicyCommandInterest : public ValidationPolicy
 {
 public:
   class Options {

--- a/include/ndn-ind/security/v2/validation-policy-config.hpp
+++ b/include/ndn-ind/security/v2/validation-policy-config.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/v2/validation-policy-config.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,7 +51,7 @@ class BoostInfoTree;
  * terminal inner policy).
  * @see https://named-data.net/doc/ndn-cxx/current/tutorials/security-validator-config.html
  */
-class ValidationPolicyConfig : public ValidationPolicy {
+class ndn_ind_dll ValidationPolicyConfig : public ValidationPolicy {
 public:
   /**
    * Create a default ValidationPolicyConfig.

--- a/include/ndn-ind/security/v2/validation-policy-from-pib.hpp
+++ b/include/ndn-ind/security/v2/validation-policy-from-pib.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-policy-from-pib.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * policy that validates a packet using the default certificate of the key in
  * the PIB that is named by the packet's KeyLocator.
  */
-class ValidationPolicyFromPib : public ValidationPolicy {
+class ndn_ind_dll ValidationPolicyFromPib : public ValidationPolicy {
 public:
   /**
    * Create a ValidationPolicyFromPib to use the given PIB.

--- a/include/ndn-ind/security/v2/validation-policy-simple-hierarchy.hpp
+++ b/include/ndn-ind/security/v2/validation-policy-simple-hierarchy.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-policy-simple-hierarchy.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validation-policy-simple-hierarchy.hpp
@@ -31,7 +43,7 @@ namespace ndn {
  * ValidationPolicySimpleHierarchy extends ValidationPolicy to implement a
  * Validation policy for a simple hierarchical trust model.
  */
-class ValidationPolicySimpleHierarchy : public ValidationPolicy {
+class ndn_ind_dll ValidationPolicySimpleHierarchy : public ValidationPolicy {
 public:
   virtual void
   checkPolicy

--- a/include/ndn-ind/security/v2/validation-policy.hpp
+++ b/include/ndn-ind/security/v2/validation-policy.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-policy.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validation-policy.hpp
@@ -38,7 +50,7 @@ class Validator;
  * ValidationPolicy is an abstract base class that implements a validation
  * policy for Data and Interest packets.
  */
-class ValidationPolicy {
+class ndn_ind_dll ValidationPolicy {
 public:
   typedef func_lib::function<void
     (const ptr_lib::shared_ptr<CertificateRequest>& certificateRequest,

--- a/include/ndn-ind/security/v2/validation-state.hpp
+++ b/include/ndn-ind/security/v2/validation-state.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validation-state.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validation-state.hpp
@@ -77,7 +89,7 @@ typedef func_lib::function<void
  * A validation policy and/or key fetcher may add custom information associated
  * with the validation state using tags.
  */
-class ValidationState {
+class ndn_ind_dll ValidationState {
 public:
   ValidationState()
   : hasOutcome_(false)
@@ -214,7 +226,7 @@ private:
  * The DataValidationState class extends ValidationState to hold the validation
  * state for a Data packet.
  */
-class DataValidationState : public ValidationState {
+class ndn_ind_dll DataValidationState : public ValidationState {
 public:
   /**
    * Create a DataValidationState for the Data packet.
@@ -256,7 +268,7 @@ private:
  * The InterestValidationState class extends ValidationState to hold the
  * validation state for an Interest packet.
  */
-class InterestValidationState : public ValidationState {
+class ndn_ind_dll InterestValidationState : public ValidationState {
 public:
   /**
    * Create an InterestValidationState for the Data packet.

--- a/include/ndn-ind/security/v2/validator-config/config-checker.hpp
+++ b/include/ndn-ind/security/v2/validator-config/config-checker.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validator-config/config-checker.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator-config/checker.hpp
@@ -37,7 +49,7 @@ class NdnRegexTopMatcher;
  * used by ValidatorConfig to check if a packet name and KeyLocator satisfy the
  * conditions in a configuration section.
  */
-class ConfigChecker {
+class ndn_ind_dll ConfigChecker {
 public:
   virtual
   ~ConfigChecker();

--- a/include/ndn-ind/security/v2/validator-config/config-filter.hpp
+++ b/include/ndn-ind/security/v2/validator-config/config-filter.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validator-config/config-filter.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator-config/filter.hpp
@@ -38,7 +50,7 @@ class NdnRegexTopMatcher;
  * The Filter class is a part of a rule and is used to match a packet.
  * Matched packets will be checked against the checkers defined in the rule.
  */
-class ConfigFilter {
+class ndn_ind_dll ConfigFilter {
 public:
   virtual
   ~ConfigFilter();

--- a/include/ndn-ind/security/v2/validator-config/config-name-relation.hpp
+++ b/include/ndn-ind/security/v2/validator-config/config-name-relation.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validator-config/config-name-relation.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator-config/name-relation.hpp
@@ -30,7 +42,7 @@ namespace ndn {
 /** ConfigNameRelation defines the ConfigNameRelation::Relation enum and static
  * methods to work with name relations for the ValidatorConfig.
  */
-class ConfigNameRelation {
+class ndn_ind_dll ConfigNameRelation {
 public:
   enum Relation {
     EQUAL,

--- a/include/ndn-ind/security/v2/validator-config/config-rule.hpp
+++ b/include/ndn-ind/security/v2/validator-config/config-rule.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validator-config/config-rule.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator-config/rule.hpp
@@ -33,7 +45,7 @@ class BoostInfoTree;
 /**
  * A ConfigRule represents a rule configuration section, used by ConfigValidator.
  */
-class ConfigRule {
+class ndn_ind_dll ConfigRule {
 public:
   /**
    * Create a ConfigRule with empty filters and checkers.

--- a/include/ndn-ind/security/v2/validator.hpp
+++ b/include/ndn-ind/security/v2/validator.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/v2/validator.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator.hpp
@@ -52,7 +64,7 @@ namespace ndn {
  * already verified, and an unverified certificate cache for saving pre-fetched
  * but not yet verified certificates.
  */
-class Validator : public CertificateStorage {
+class ndn_ind_dll Validator : public CertificateStorage {
 public:
   /**
    * Create a Validator with the policy and fetcher.

--- a/include/ndn-ind/security/validator-config-error.hpp
+++ b/include/ndn-ind/security/validator-config-error.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/validator-config-error.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/v2/validator-config/common.hpp
@@ -31,7 +43,7 @@ namespace ndn {
  * A ValidatorConfigError extends runtime_error and represents an error using
  * ValidatorConfig.
  */
-class ValidatorConfigError : public std::runtime_error
+class ndn_ind_dll ValidatorConfigError : public std::runtime_error
 {
 public:
   ValidatorConfigError(const std::string& what)

--- a/include/ndn-ind/security/validator-null.hpp
+++ b/include/ndn-ind/security/validator-null.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/validator-null.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/validator-null.hpp
@@ -31,7 +43,7 @@ namespace ndn {
  * A ValidatorNull extends Validator with an "accept-all" policy and an offline
  * certificate fetcher.
  */
-class ValidatorNull : public Validator {
+class ndn_ind_dll ValidatorNull : public Validator {
 public:
   ValidatorNull();
 };

--- a/include/ndn-ind/security/validity-period.hpp
+++ b/include/ndn-ind/security/validity-period.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/security/validity-period.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -46,7 +46,7 @@ namespace ndn {
  * A ValidityPeriod is used in a Data packet's SignatureInfo and represents the
  * begin and end times of a certificate's validity period.
  */
-class ValidityPeriod {
+class ndn_ind_dll ValidityPeriod {
 public:
   /** Create a default ValidityPeriod where the period is not specified.
    */

--- a/include/ndn-ind/security/verification-helpers.hpp
+++ b/include/ndn-ind/security/verification-helpers.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/security/verification-helpers.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2017-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  * @author: From ndn-cxx security https://github.com/named-data/ndn-cxx/blob/master/ndn-cxx/security/verification-helpers.hpp
@@ -33,7 +45,7 @@ namespace ndn {
  * The VerificationHelpers class has static methods to verify signatures and
  * digests.
  */
-class VerificationHelpers {
+class ndn_ind_dll VerificationHelpers {
 public:
   /**
    * Verify the buffer against the signature using the public key.

--- a/include/ndn-ind/sha256-with-ecdsa-signature.hpp
+++ b/include/ndn-ind/sha256-with-ecdsa-signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/sha256-with-ecdsa-signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * A Sha256WithEcdsaSignature extends Signature and holds the signature bits and
  * other info representing a SHA256-with-ECDSA signature in a data packet.
  */
-class Sha256WithEcdsaSignature : public Signature {
+class ndn_ind_dll Sha256WithEcdsaSignature : public Signature {
 public:
   Sha256WithEcdsaSignature()
   : changeCount_(0)

--- a/include/ndn-ind/sha256-with-rsa-signature.hpp
+++ b/include/ndn-ind/sha256-with-rsa-signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/sha256-with-rsa-signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2013-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -33,7 +45,7 @@ namespace ndn {
  * A Sha256WithRsaSignature extends Signature and holds the signature bits and other info representing a
  * SHA256-with-RSA signature in a data packet.
  */
-class Sha256WithRsaSignature : public Signature {
+class ndn_ind_dll Sha256WithRsaSignature : public Signature {
 public:
   Sha256WithRsaSignature()
   : changeCount_(0)

--- a/include/ndn-ind/signature.hpp
+++ b/include/ndn-ind/signature.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/signature.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -32,7 +44,7 @@ namespace ndn {
  * A Signature is an abstract base class providing methods to work with the signature information in a Data packet.
  * You must create an object of a subclass, for example Sha256WithRsaSignature.
  */
-class Signature {
+class ndn_ind_dll Signature {
 public:
   /**
    * The virtual destructor.

--- a/include/ndn-ind/sync/chrono-sync2013.hpp
+++ b/include/ndn-ind/sync/chrono-sync2013.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/sync/chrono-sync2013.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -56,7 +56,7 @@ class DigestTree;
  * See the API docs for more detail at
  * http://named-data.net/doc/ndn-ccl-api/chrono-sync2013.html .
  */
-class ChronoSync2013 {
+class ndn_ind_dll ChronoSync2013 {
 public:
   class SyncState;
   typedef func_lib::function<void

--- a/include/ndn-ind/sync/full-psync2017-with-users.hpp
+++ b/include/ndn-ind/sync/full-psync2017-with-users.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/sync/full-psync2017-with-users.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -58,7 +58,7 @@ class PSyncUserPrefixes;
  * the class actually handles both producing and consuming, we omit "producer"
  * in the name to avoid confusion.)
  */
-class FullPSync2017WithUsers {
+class ndn_ind_dll FullPSync2017WithUsers {
 public:
   typedef func_lib::function<void
     (const ptr_lib::shared_ptr<std::vector<ptr_lib::shared_ptr<PSyncMissingDataInfo>>>& updates)> OnUpdate;

--- a/include/ndn-ind/sync/full-psync2017.hpp
+++ b/include/ndn-ind/sync/full-psync2017.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/sync/full-psync2017.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -61,7 +61,7 @@ class PSyncSegmentPublisher;
  * because the class actually handles both producing and consuming, we omit
  * "producer" in the name to avoid confusion.)
  */
-class FullPSync2017 {
+class ndn_ind_dll FullPSync2017 {
 public:
   typedef func_lib::function<void
     (const ptr_lib::shared_ptr<std::vector<Name>>& updates)> OnNamesUpdate;

--- a/include/ndn-ind/sync/psync-missing-data-info.hpp
+++ b/include/ndn-ind/sync/psync-missing-data-info.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/sync/psync-missing-data-info.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2019-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -26,7 +38,7 @@
 
 namespace ndn {
 
-class PSyncMissingDataInfo
+class ndn_ind_dll PSyncMissingDataInfo
 {
 public:
   PSyncMissingDataInfo

--- a/include/ndn-ind/sync/psync-producer-base.hpp
+++ b/include/ndn-ind/sync/psync-producer-base.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/sync/psync-producer-base.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -46,7 +46,7 @@ class InvertibleBloomLookupTable;
  * PSyncProducerBase is a base class for PsyncPartialProducer::Impl and
  * FullPSync2017::Impl.
  */
-class PSyncProducerBase : public ptr_lib::enable_shared_from_this<PSyncProducerBase> {
+class ndn_ind_dll PSyncProducerBase : public ptr_lib::enable_shared_from_this<PSyncProducerBase> {
 protected:
   /**
    * Create a PSyncProducerBase.

--- a/include/ndn-ind/threadsafe-face.hpp
+++ b/include/ndn-ind/threadsafe-face.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/threadsafe-face.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Use std::chrono.
+ * Summary of Changes: Use NDN_IND macros. Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -50,7 +50,7 @@ namespace ndn {
  * which you want the library to call communication callbacks such as onData and
  * onInterest. For usage, see the example test-get-async-threadsafe.cpp.
  */
-class ThreadsafeFace : public Face {
+class ndn_ind_dll ThreadsafeFace : public Face {
 public:
   /**
    * Create a new Face for communication with an NDN hub with the given

--- a/include/ndn-ind/transport/async-tcp-transport.hpp
+++ b/include/ndn-ind/transport/async-tcp-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/transport/async-tcp-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Add readRawPackets.
+ * Summary of Changes: Use NDN_IND macros. Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -52,7 +52,7 @@ namespace ndn {
  * thread-safe, you must dispatch calls to send(), etc. to the io_service, as is
  * done by ThreadsafeFace. To use this, you do not need to call processEvents.
  */
-class AsyncTcpTransport : public Transport {
+class ndn_ind_dll AsyncTcpTransport : public Transport {
 public:
   /**
    * An AsyncTcpTransport::ConnectionInfo extends Transport::ConnectionInfo to

--- a/include/ndn-ind/transport/async-unix-transport.hpp
+++ b/include/ndn-ind/transport/async-unix-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/transport/async-unix-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros. Add readRawPackets.
+ * Summary of Changes: Use NDN_IND macros. Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -54,7 +54,7 @@ template<class AsioProtocol> class AsyncSocketTransport;
  * io_service, as is done by ThreadsafeFace. To use this, you do not need to
  * call processEvents.
  */
-class AsyncUnixTransport : public Transport {
+class ndn_ind_dll AsyncUnixTransport : public Transport {
 public:
   /**
    * An AsyncUnixTransport::ConnectionInfo extends Transport::ConnectionInfo to

--- a/include/ndn-ind/transport/tcp-transport.hpp
+++ b/include/ndn-ind/transport/tcp-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/transport/tcp-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ class DynamicUInt8Vector;
  * TcpTransport extends the Transport interface to implement communication over
  * TCP.
  */
-class TcpTransport : public Transport {
+class ndn_ind_dll TcpTransport : public Transport {
 public:
   /**
    * A TcpTransport::ConnectionInfo extends Transport::ConnectionInfo to hold

--- a/include/ndn-ind/transport/transport.hpp
+++ b/include/ndn-ind/transport/transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/transport/transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Put element-listener.hpp in API.
+ * Summary of Changes: Put element-listener.hpp in API. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -44,7 +44,7 @@ namespace ndn {
  * A Transport object is used by Face to send packets and to listen for incoming
  * packets. See connect() and processEvents() for more details.
  */
-class Transport {
+class ndn_ind_dll Transport {
 public:
   /**
    * A Transport::ConnectionInfo is a base class for connection information used

--- a/include/ndn-ind/transport/udp-transport.hpp
+++ b/include/ndn-ind/transport/udp-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/transport/udp-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -48,7 +48,7 @@ class DynamicUInt8Vector;
  * UdpTransport extends the Transport interface to implement communication over
  * UDP.
  */
-class UdpTransport : public Transport {
+class ndn_ind_dll UdpTransport : public Transport {
 public:
   /**
    * A UdpTransport::ConnectionInfo extends Transport::ConnectionInfo to hold

--- a/include/ndn-ind/transport/unix-transport.hpp
+++ b/include/ndn-ind/transport/unix-transport.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-ind/transport/unix-transport.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Add readRawPackets.
+ * Summary of Changes: Add readRawPackets. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -34,6 +34,10 @@
 #ifndef NDN_UNIX_TRANSPORT_HPP
 #define NDN_UNIX_TRANSPORT_HPP
 
+ // Only compile if we have Unix socket support.
+#include <ndn-ind/ndn-ind-config.h>
+#if NDN_IND_HAVE_UNISTD_H
+
 #include <string>
 #include "../common.hpp"
 #include "transport.hpp"
@@ -48,7 +52,7 @@ class DynamicUInt8Vector;
  * UnixTransport extends the Transport interface to implement communication over
  * a Unix socket.
  */
-class UnixTransport : public Transport {
+class ndn_ind_dll UnixTransport : public Transport {
 public:
   /**
    * A UnixTransport::ConnectionInfo extends Transport::ConnectionInfo to hold
@@ -155,5 +159,7 @@ private:
 };
 
 }
+
+#endif // NDN_IND_HAVE_UNISTD_H
 
 #endif

--- a/include/ndn-ind/util/blob.hpp
+++ b/include/ndn-ind/util/blob.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/util/blob.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,7 +51,7 @@ namespace ndn {
  * a pointer to it like Blob, but this does not enforce immutability because we can't declare
  * Blob as derived from const vector<uint8_t>.)
  */
-class Blob : public ptr_lib::shared_ptr<const std::vector<uint8_t> > {
+class ndn_ind_dll Blob : public ptr_lib::shared_ptr<const std::vector<uint8_t> > {
 public:
   /**
    * Create a new Blob with a null pointer.

--- a/include/ndn-ind/util/change-counter.hpp
+++ b/include/ndn-ind/util/change-counter.hpp
@@ -1,5 +1,17 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
+ * Copyright (C) 2020 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This works is based substantially on previous work as listed below:
+ *
+ * Original file: include/ndn-cpp/util/change-counter.hpp
+ * Original repository: https://github.com/named-data/ndn-cpp
+ *
+ * Summary of Changes: Support ndn_ind_dll.
+ *
+ * which was originally released under the LGPL license with the following rights:
+ *
  * Copyright (C) 2014-2020 Regents of the University of California.
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
  *
@@ -34,7 +46,7 @@ namespace ndn {
  * If you need the target to be a shared_ptr, see SharedPointerChangeCounter.
  */
 template<class T>
-class ChangeCounter {
+class ndn_ind_dll ChangeCounter {
 public:
   /**
    * Create a new ChangeCounter with a default value for the target.  This sets the local change counter to target_.getChangeCount().
@@ -114,7 +126,7 @@ private:
  * If you need the target to be a normal value type, see ChangeCounter.
  */
 template<class T>
-class SharedPointerChangeCounter {
+class ndn_ind_dll SharedPointerChangeCounter {
 public:
   /**
    * Create a new SharedPointerChangeCounter with a default a null shared_ptr for the target.

--- a/include/ndn-ind/util/exponential-re-express.hpp
+++ b/include/ndn-ind/util/exponential-re-express.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/util/exponential-re-express.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -43,7 +43,7 @@ namespace ndn {
  * again with double the interestLifetime. See
  * ExponentialReExpress.makeOnTimeout.
  */
-class ExponentialReExpress : public ptr_lib::enable_shared_from_this<ExponentialReExpress> {
+class ndn_ind_dll ExponentialReExpress : public ptr_lib::enable_shared_from_this<ExponentialReExpress> {
 public:
   /**
    * Return a function object to use in expressInterest for onTimeout which will

--- a/include/ndn-ind/util/impl/cancel-handle.hpp
+++ b/include/ndn-ind/util/impl/cancel-handle.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cxx
  *
  * Summary of Changes: Conditional compile on NDN_IND_HAVE_BOOST_ASIO. Added ScopedCancelHandle.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -38,6 +39,7 @@
 #ifndef NDN_DETAIL_CANCEL_HANDLE_HPP
 #define NDN_DETAIL_CANCEL_HANDLE_HPP
 
+#include "../../c/common.h"
 #include <functional>
 
 namespace ndn {
@@ -45,7 +47,7 @@ namespace scheduler {
 
 /** \brief Handle to cancel an operation.
  */
-class CancelHandle
+class ndn_ind_dll CancelHandle
 {
 public:
   CancelHandle() noexcept = default;
@@ -64,7 +66,7 @@ private:
 
 /** \brief Cancels an operation automatically upon destruction.
  */
-class ScopedCancelHandle
+class ndn_ind_dll ScopedCancelHandle
 {
 public:
   ScopedCancelHandle() noexcept = default;

--- a/include/ndn-ind/util/impl/monotonic_steady_clock.hpp
+++ b/include/ndn-ind/util/impl/monotonic_steady_clock.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cxx
  *
  * Summary of Changes: Rename steady_clock to MonotonicSteadyClock. Remove other unused code.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -51,7 +52,7 @@ namespace scheduler {
  * On most systems, this is the same as std::chrono::stead_clock. But on macOS,
  * we need to override the behavior of now() so that it is monotonic.
  */
-class MonotonicSteadyClock
+class ndn_ind_dll MonotonicSteadyClock
 {
 public:
   using duration   = std::chrono::steady_clock::duration;

--- a/include/ndn-ind/util/impl/steady-timer.hpp
+++ b/include/ndn-ind/util/impl/steady-timer.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cxx
  *
  * Summary of Changes: Conditional compile on NDN_IND_HAVE_BOOST_ASIO. Use base class MonotonicSteadyClock.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -45,7 +46,7 @@
 namespace ndn {
 namespace scheduler {
 
-class SteadyTimer : public boost::asio::basic_waitable_timer<MonotonicSteadyClock>
+class ndn_ind_dll SteadyTimer : public boost::asio::basic_waitable_timer<MonotonicSteadyClock>
 {
 public:
   using boost::asio::basic_waitable_timer<MonotonicSteadyClock>::basic_waitable_timer;

--- a/include/ndn-ind/util/memory-content-cache.hpp
+++ b/include/ndn-ind/util/memory-content-cache.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/util/memory-content-cache.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use std::chrono.
+ * Summary of Changes: Use std::chrono. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -47,7 +47,7 @@ namespace ndn {
  * @note This class is an experimental feature.  See the API docs for more detail at
  * http://named-data.net/doc/ndn-ccl-api/memory-content-cache.html .
  */
-class MemoryContentCache {
+class ndn_ind_dll MemoryContentCache {
 public:
   /**
    * Create a new MemoryContentCache to use the given Face.

--- a/include/ndn-ind/util/scheduler.hpp
+++ b/include/ndn-ind/util/scheduler.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cxx
  *
  * Summary of Changes: Use ndn-ind includes and namespace. Use std::chrono and shared_ptr.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -70,7 +71,7 @@ using EventCallback = std::function<void()>;
  *  \warning Canceling an event after the scheduler has been destructed may trigger undefined
  *           behavior.
  */
-class EventId : public CancelHandle
+class ndn_ind_dll EventId : public CancelHandle
 {
 public:
   /** \brief Constructs an empty EventId
@@ -131,7 +132,7 @@ operator<<(std::ostream& os, const EventId& eventId);
  *  \warning Canceling an event after the scheduler has been destructed may trigger undefined
  *           behavior.
  */
-class ScopedEventId : public ScopedCancelHandle
+class ndn_ind_dll ScopedEventId : public ScopedCancelHandle
 {
 public:
   using ScopedCancelHandle::ScopedCancelHandle;
@@ -141,7 +142,7 @@ public:
 
 /** \brief Generic time-based scheduler
  */
-class Scheduler : boost::noncopyable
+class ndn_ind_dll Scheduler : boost::noncopyable
 {
 public:
   explicit

--- a/include/ndn-ind/util/segment-fetcher.hpp
+++ b/include/ndn-ind/util/segment-fetcher.hpp
@@ -9,6 +9,7 @@
  * Original repository: https://github.com/named-data/ndn-cpp
  *
  * Summary of Changes: Use std::chrono. Remove unused methods from security v1.
+ *   Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -95,7 +96,7 @@ namespace ndn {
  *
  *     SegmentFetcher.fetch(face, interest, 0, onComplete, onError);
  */
-class SegmentFetcher : public ptr_lib::enable_shared_from_this<SegmentFetcher> {
+class ndn_ind_dll SegmentFetcher : public ptr_lib::enable_shared_from_this<SegmentFetcher> {
 public:
   enum ErrorCode {
     INTEREST_TIMEOUT = 1,

--- a/include/ndn-ind/util/signed-blob.hpp
+++ b/include/ndn-ind/util/signed-blob.hpp
@@ -8,7 +8,7 @@
  * Original file: include/ndn-cpp/util/signed-blob.hpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use NDN_IND macros.
+ * Summary of Changes: Use NDN_IND macros. Support ndn_ind_dll.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -43,7 +43,7 @@ namespace ndn {
 /**
  * A SignedBlob extends Blob to keep the offsets of a signed portion (e.g., the bytes of Data packet).
  */
-class SignedBlob : public Blob {
+class ndn_ind_dll SignedBlob : public Blob {
 public:
   /**
    * Create a new SignedBlob with a null pointer.

--- a/src/c/encoding/tlv/tlv-signature-info.c
+++ b/src/c/encoding/tlv/tlv-signature-info.c
@@ -121,7 +121,7 @@ decodeValidityPeriod
   ndn_Error error;
   size_t endOffset;
   // Expect a 15-character ISO string like "20131018T184139".
-  const size_t isoStringMaxLength = 15;
+  enum { isoStringMaxLength = 15 };
   char isoString[isoStringMaxLength + 1];
   struct ndn_Blob isoStringBlob;
 

--- a/src/c/transport/socket-transport.h
+++ b/src/c/transport/socket-transport.h
@@ -7,7 +7,7 @@
  * Original file: src/c/transport/socket-transport.h
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -68,7 +68,12 @@ static __inline void ndn_SocketTransport_initialize
   (struct ndn_SocketTransport *self, struct ndn_DynamicUInt8Array *buffer,
    int readRawPackets)
 {
+#if defined(_WIN32)
+  self->socketDescriptor = INVALID_SOCKET;
+#else
   self->socketDescriptor = -1;
+#endif
+
   ndn_ElementReader_initialize(&self->elementReader, 0, buffer, readRawPackets);
 }
 

--- a/src/c/transport/tcp-transport_c.c
+++ b/src/c/transport/tcp-transport_c.c
@@ -7,7 +7,7 @@
  * Original file: src/c/transport/socket-transport_c.c
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes.
+ * Summary of Changes: Use ndn-ind includes. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -81,5 +81,18 @@ ndn_TcpTransport_isLocal(const char *host, int *result)
   freeaddrinfo(serverInfo);
   return NDN_ERROR_success;
 }
+
+#else
+
+#if defined(_WIN32)
+#include "tcp-transport.h"
+ndn_Error
+ndn_TcpTransport_isLocal(const char* host, int* result)
+{
+  // Assume that NFD is not running on the Windows machine, so not local.
+  *result = 0;
+  return NDN_ERROR_success;
+}
+#endif
 
 #endif // NDN_IND_HAVE_UNISTD_H

--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -39,6 +39,8 @@
 #endif
 #if defined(_WIN32)
 #include <Windows.h>
+// Windows doesn't have timegm, but _mkgmtime does the same thing.
+static time_t timegm(struct tm* t) { return _mkgmtime(t); }
 #endif
 #include <math.h>
 #include <string.h>
@@ -75,7 +77,7 @@ ndn_Error
 ndn_toIsoString
   (ndn_MillisecondsSince1970 milliseconds, int includeFraction, char *isoString)
 {
-#if NDN_IND_HAVE_GMTIME_SUPPORT
+#if NDN_IND_HAVE_GMTIME_SUPPORT || defined(_WIN32)
   double secondsSince1970;
   char fractionBuffer[10];
   const char *fraction;
@@ -115,7 +117,7 @@ ndn_toIsoString
 ndn_Error
 ndn_fromIsoString(const char* isoString, ndn_MillisecondsSince1970 *milliseconds)
 {
-#if NDN_IND_HAVE_GMTIME_SUPPORT
+#if NDN_IND_HAVE_GMTIME_SUPPORT || defined(_WIN32)
   // Initialize time zone, etc.
   time_t dummyTime = 0;
   struct tm tm1 = *gmtime(&dummyTime);

--- a/src/encrypt/encryptor-v2.cpp
+++ b/src/encrypt/encryptor-v2.cpp
@@ -52,6 +52,10 @@ INIT_LOGGER("ndn.EncryptorV2");
 
 namespace ndn {
 
+ndn_ind_dll const std::chrono::nanoseconds RETRY_DELAY_AFTER_NACK = std::chrono::seconds(1);
+ndn_ind_dll const std::chrono::nanoseconds RETRY_DELAY_KEK_RETRIEVAL = std::chrono::minutes(1);
+ndn_ind_dll const std::chrono::nanoseconds DEFAULT_CK_FRESHNESS_PERIOD = std::chrono::hours(1);
+
 void
 EncryptorV2::encrypt
   (const ptr_lib::shared_ptr<Interest>& interest,

--- a/src/lite/transport/tcp-transport-lite.cpp
+++ b/src/lite/transport/tcp-transport-lite.cpp
@@ -8,7 +8,7 @@
  * Original file: src/lite/transport/tcp-transport-lite.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -31,9 +31,9 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
-// Only compile if we have Unix socket support.
+// Only compile if we have Unix or Windows socket support.
 #include <ndn-ind/ndn-ind-config.h>
-#if NDN_IND_HAVE_UNISTD_H
+#if NDN_IND_HAVE_UNISTD_H || defined(_WIN32)
 
 #include "../../c/transport/tcp-transport.h"
 #include <ndn-ind/lite/transport/tcp-transport-lite.hpp>

--- a/src/lite/transport/udp-transport-lite.cpp
+++ b/src/lite/transport/udp-transport-lite.cpp
@@ -8,7 +8,7 @@
  * Original file: src/lite/transport/udp-transport-lite.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -31,9 +31,9 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
-// Only compile if we have Unix socket support.
+// Only compile if we have Unix or Windows socket support.
 #include <ndn-ind/ndn-ind-config.h>
-#if NDN_IND_HAVE_UNISTD_H
+#if NDN_IND_HAVE_UNISTD_H || defined(_WIN32)
 
 #include "../../c/transport/udp-transport.h"
 #include <ndn-ind/lite/transport/udp-transport-lite.hpp>

--- a/src/security/key-chain.cpp
+++ b/src/security/key-chain.cpp
@@ -621,7 +621,11 @@ KeyChain::parseAndCheckTpmLocator
 string
 KeyChain::getDefaultPibScheme()
 {
+#ifdef NDN_IND_HAVE_SQLITE3
   return NDN_PIB_SQLITE3_SCHEME;
+#else
+  return "";
+#endif
 }
 
 string
@@ -671,6 +675,9 @@ KeyChain::getDefaultPibLocator(ConfigFile& config)
     *defaultPibLocator_ = clientPib;
   else
      *defaultPibLocator_ = config.get("pib", getDefaultPibScheme() + ":");
+  if (*defaultPibLocator_ == ":")
+    // No default to check.
+    return *defaultPibLocator_;
 
   string pibScheme, pibLocation;
   parseAndCheckPibLocator(*defaultPibLocator_, pibScheme, pibLocation);

--- a/src/security/tpm/tpm-back-end-file.cpp
+++ b/src/security/tpm/tpm-back-end-file.cpp
@@ -43,6 +43,9 @@
 #ifdef NDN_IND_HAVE_BOOST_FILESYSTEM
 #include <boost/filesystem.hpp>
 #endif
+#if defined(_WIN32)
+#include <direct.h>
+#endif
 #include <ndn-ind/security/tpm/tpm-back-end-file.hpp>
 
 using namespace std;
@@ -75,11 +78,15 @@ TpmBackEndFile::TpmBackEndFile(const string& locationPath)
   }
 
   // ::mkdir will work if the parent directory already exists, which is most cases.
+#if defined(_WIN32)
+  int status = ::_mkdir(keyStorePath_.c_str());
+#else
   int status = ::mkdir(keyStorePath_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+#endif
   // EEXIST means the directory already exists, so it's OK.
   if (status != 0 && status != EEXIST) {
     // Can't create the directory with ::mkdir.
-#ifdef NDN_IND_HAVE_CXX17
+#ifdef NDN_IND_HAVE_BOOST_FILESYSTEM
     // Try with create_directories.
     boost::filesystem::create_directories(keyStorePath_);
 #else

--- a/src/transport/tcp-transport.cpp
+++ b/src/transport/tcp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/tcp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -31,9 +31,9 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
-// Only compile if we have Unix socket support.
+// Only compile if we have Unix or Windows socket support.
 #include <ndn-ind/ndn-ind-config.h>
-#if NDN_IND_HAVE_UNISTD_H
+#if NDN_IND_HAVE_UNISTD_H || defined(_WIN32)
 
 #include <stdexcept>
 #include <stdlib.h>

--- a/src/transport/udp-transport.cpp
+++ b/src/transport/udp-transport.cpp
@@ -8,7 +8,7 @@
  * Original file: src/transport/udp-transport.cpp
  * Original repository: https://github.com/named-data/ndn-cpp
  *
- * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API.
+ * Summary of Changes: Use ndn-ind includes. Add readRawPackets. Put element-listener.hpp in API. Support WinSock2.
  *
  * which was originally released under the LGPL license with the following rights:
  *
@@ -31,9 +31,9 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
-// Only compile if we have Unix socket support.
+// Only compile if we have Unix or Windows socket support.
 #include <ndn-ind/ndn-ind-config.h>
-#if NDN_IND_HAVE_UNISTD_H
+#if NDN_IND_HAVE_UNISTD_H || defined(_WIN32)
 
 #include <stdexcept>
 #include <stdlib.h>


### PR DESCRIPTION
The vcpkg package manager supports openssl which is a prerequisite for NDN-IND. So now we can make a Visual Studio project to build `ndn-ind.dll` and support native Windows applications. This pull request has 12 commits, grouped as follows:

Commits 1 and 10 add the folder VisualStudio with the Visual Studio projects to build `ndn-ind.dll` and the example application.

Commits 2, 3, 4, 7 and 9 make small changes to the library code as required by the Visual Studio compiler. See the individual commit messages for details.

Commit 5 updates the socket transport code in C to support WinSock2. This is similar enough to the existing Unix socket code that we just add some `#if defined(_WIN32)` as needed where the code is different. And commit 6 updates the higher-level classes for TcpTransport, etc. to allow being compiled on Windows.

Commit 8 adds the version of `ndn-ind-config.h` to be used with Visual Studio. Normally this file is created by running`./configure` on Unix, but here it must be manually copied to the include directory.

Commit 11 affects all header files in the public API. To make a DLL, Visual Studio requires `__declspec(dllexport)` on all exported classes, functions and global variables. (And when these are used by the DLL itself, they must say `__declspec(dllimport)`. Therefore, the following code in `common.h` defines `ndn_ind_dll`:

    if defined(_WIN32)
      #ifdef NDN_IND_EXPORTS
        #define ndn_ind_dll __declspec(dllexport)
      #else
        #define ndn_ind_dll __declspec(dllimport)
      #endif
    #else
      #define ndn_ind_dll
    #endif

And all exported entities must use it. For example `class ndn_ind_dll Face`. This commit also updates the copyright headers to mention adding the support for `ndn_ind_dll`.

Finally, commit 12 adds the build instructions `VisualStudio/Visual-Studio-README.md`, mentions this file in the main INSTALL file, and updates the CHANGELOG.