### PR TITLE
examples: Add optional command-line arguments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2020-12-08)
+NDN-IND (2020-12-14)
 --------------------
 
 Changes
@@ -25,6 +25,7 @@ Changes
 * In examples and unit tests, use the default Face which doesn't require TCP.
 * Move the instructions for RHEL 7 to the wiki.
 * Add support for Visual Studio. https://github.com/operantnetworks/ndn-ind/pull/17
+* In examples, add optional command-line arguments. https://github.com/operantnetworks/ndn-ind/pull/18
 
 Bug fixes
 * In expressInterest, use the nonce in the Interest if provided.


### PR DESCRIPTION
This pull request updates the most commonly-used example programs with optional command-line arguments. Following are the help message for each.

    Usage: test-echo-consumer [options]
      -n name-prefix  If omitted, use /testecho
      -h host         If omitted or "", the default Face connects to the local forwarder
      -p port         If omitted, use 6363
      -?              Print this help

    Usage: test-publish-async-nfd [options]
      -n name-prefix  If omitted, use /testecho
      -k              Keep responding. If omitted, quit after one response
      -?              Print this help

    Usage: test-access-manager [options]
      -d dataset                 The dataset part of the access group name. If omitted, use /test-group
      -i access-manager-identity The access manager identity name. This must be an identity on the system.
                                 If omitted, use the system default identity. The access group name is
                                 <access-manager-identity>/NAC/<dataset>
      -?                         Print this help

    Usage: test-secured-interest-sender [options]
      -a access-group-name The access group name as printed by test-access-manager. If omitted, use
                           <default-identity>/NAC/test-group where <default-identity> is the system default identity.
      -n name-prefix       The name prefix for the message. If omitted, use /test-secured-interest
                           This must match the prefix for test-secured-interest-responder.
      -h host              If omitted or "", the default Face connects to the local forwarder
                           Both test-access-manager and test-secured-interest-responder must be reachable.
      -p port              If omitted, use 6363
      -?                   Print this help

    Usage: test-secured-interest-responder [options]
      -a access-group-name The access group name as printed by test-access-manager. If omitted, use
                           <default-identity>/NAC/test-group where <default-identity> is the system default identity.
      -n name-prefix       The name prefix for the message. If omitted, use /test-secured-interest
                           This must match the prefix for test-secured-interest-sender.
      -k                   Keep responding. If omitted, quit after one response
      -?                   Print this help

