### PR TITLE
CodeDX findings (High and Medium)

### DIFF
--- a/contrib/murmur-hash/murmur-hash.c
+++ b/contrib/murmur-hash/murmur-hash.c
@@ -33,7 +33,7 @@ ndn_murmurHash3
   const uint32_t* blocks = (const uint32_t*)(dataToHash + nblocks * 4);
 
   int i;
-  for (i = -(int)nblocks; i < 0; i++) {
+  for (i = -(int)nblocks; i < 0; ++i) {
     // Note that this indexes backwards from the end of the array.
     uint32_t k2 = blocks[i];
 

--- a/src/c/util/ndn_memory.c
+++ b/src/c/util/ndn_memory.c
@@ -37,7 +37,7 @@ int ndn_memcmp(const uint8_t *buf1, const uint8_t *buf2, size_t len)
 {
   size_t i;
 
-  for (i = 0; i < len; i++) {
+  for (i = 0; i < len; ++i) {
     if (buf1[i] > buf2[i])
       return 1;
     else if (buf1[i] < buf2[i])
@@ -55,7 +55,7 @@ void ndn_memcpy(uint8_t *dest, const uint8_t *src, size_t len)
 {
   size_t i;
 
-  for (i = 0; i < len; i++)
+  for (i = 0; i < len; ++i)
     dest[i] = src[i];
 }
 #else
@@ -67,7 +67,7 @@ void ndn_memset(uint8_t *dest, int val, size_t len)
 {
   size_t i;
 
-  for (i = 0; i < len; i++)
+  for (i = 0; i < len; ++i)
     dest[i] = (uint8_t)val;
 }
 #else

--- a/src/encoding/oid.cpp
+++ b/src/encoding/oid.cpp
@@ -73,7 +73,7 @@ string OID::toString() const
   ostringstream convert;
 
   vector<int>::const_iterator it = oid_.begin();
-  for(; it < oid_.end(); it++){
+  for(; it < oid_.end(); ++it){
     if(it != oid_.begin())
       convert << ".";
     convert << *it;
@@ -87,7 +87,7 @@ bool OID::equal(const OID& oid) const
   vector<int>::const_iterator i = oid_.begin();
   vector<int>::const_iterator j = oid.oid_.begin();
 
-  for (; i != oid_.end () && j != oid.oid_.end (); i++, j++) {
+  for (; i != oid_.end () && j != oid.oid_.end (); ++i, ++j) {
     if(*i != *j)
       return false;
   }

--- a/src/interest.cpp
+++ b/src/interest.cpp
@@ -232,7 +232,7 @@ Interest::toUri() const
 
   result << name_.get().toUri();
   string selectorsString(selectors.str());
-  if (selectorsString.size() > 0) {
+  if (selectorsString.size() > 1) {
     // Replace the first & with ?.
     result << "?";
     result.write(&selectorsString[1], selectorsString.size() - 1);

--- a/src/security/v2/validation-policy-config.cpp
+++ b/src/security/v2/validation-policy-config.cpp
@@ -186,13 +186,13 @@ void
 ValidationPolicyConfig::processConfigTrustAnchor
   (const BoostInfoTree& configSection, const string& inputName)
 {
-  const string* anchorType = configSection.getFirstValue("type");
+  ptr_lib::shared_ptr<string> anchorType = configSection.getFirstValue("type");
   if (!anchorType)
     throw ValidatorConfigError("Expected <trust-anchor.type>");
 
   if (equalsIgnoreCase(*anchorType, "file")) {
     // Get trust-anchor.file .
-    const string* fileName = configSection.getFirstValue("file-name");
+    ptr_lib::shared_ptr<string> fileName = configSection.getFirstValue("file-name");
     if (!fileName)
       throw ValidatorConfigError("Expected <trust-anchor.file-name>");
 
@@ -203,7 +203,7 @@ ValidationPolicyConfig::processConfigTrustAnchor
   }
   else if (equalsIgnoreCase(*anchorType, "base64")) {
     // Get trust-anchor.base64-string .
-    const string* base64String = configSection.getFirstValue("base64-string");
+    ptr_lib::shared_ptr<string> base64String = configSection.getFirstValue("base64-string");
     if (!base64String)
       throw ValidatorConfigError("Expected <trust-anchor.base64-string>");
 
@@ -221,7 +221,7 @@ ValidationPolicyConfig::processConfigTrustAnchor
   }
   else if (equalsIgnoreCase(*anchorType, "dir")) {
     // Get trust-anchor.dir .
-    const string* dirString = configSection.getFirstValue("dir");
+    ptr_lib::shared_ptr<string> dirString = configSection.getFirstValue("dir");
     if (!dirString)
       throw ValidatorConfigError("Expected <trust-anchor.dir>");
 
@@ -239,7 +239,7 @@ ValidationPolicyConfig::processConfigTrustAnchor
 nanoseconds
 ValidationPolicyConfig::getRefreshPeriod(const BoostInfoTree& configSection)
 {
-  const string* refreshString = configSection.getFirstValue("refresh");
+  ptr_lib::shared_ptr<string> refreshString = configSection.getFirstValue("refresh");
   if (!refreshString)
     // Return a large value (effectively no refresh).
     return milliseconds((int64_t)1e14);

--- a/src/security/v2/validator-config/config-checker.cpp
+++ b/src/security/v2/validator-config/config-checker.cpp
@@ -70,7 +70,7 @@ ptr_lib::shared_ptr<ConfigChecker>
 ConfigChecker::create(const BoostInfoTree& configSection)
 {
   // Get checker.type.
-  const string* checkerType = configSection.getFirstValue("type");
+  ptr_lib::shared_ptr<string> checkerType = configSection.getFirstValue("type");
   if (!checkerType)
     throw ValidatorConfigError("Expected <checker.type>");
 
@@ -108,7 +108,7 @@ ptr_lib::shared_ptr<ConfigChecker>
 ConfigChecker::createKeyLocatorChecker(const BoostInfoTree& configSection)
 {
   // Get checker.key-locator.type .
-  const string* keyLocatorType = configSection.getFirstValue("type");
+  ptr_lib::shared_ptr<string> keyLocatorType = configSection.getFirstValue("type");
   if (!keyLocatorType)
     throw ValidatorConfigError("Expected <checker.key-locator.type>");
 
@@ -122,11 +122,11 @@ ConfigChecker::createKeyLocatorChecker(const BoostInfoTree& configSection)
 ptr_lib::shared_ptr<ConfigChecker>
 ConfigChecker::createKeyLocatorNameChecker(const BoostInfoTree& configSection)
 {
-  const string* nameUri = configSection.getFirstValue("name");
+  ptr_lib::shared_ptr<string> nameUri = configSection.getFirstValue("name");
   if (nameUri) {
     Name name(*nameUri);
 
-    const string* relationValue = configSection.getFirstValue("relation");
+    ptr_lib::shared_ptr<string> relationValue = configSection.getFirstValue("relation");
     if (!relationValue)
       throw ValidatorConfigError("Expected <checker.key-locator.relation>");
 
@@ -135,7 +135,7 @@ ConfigChecker::createKeyLocatorNameChecker(const BoostInfoTree& configSection)
     return ptr_lib::make_shared<ConfigNameRelationChecker>(name, relation);
   }
 
-  const string* regexString = configSection.getFirstValue("regex");
+  ptr_lib::shared_ptr<string> regexString = configSection.getFirstValue("regex");
   if (regexString) {
     try {
       return ptr_lib::make_shared<ConfigRegexChecker>(*regexString);
@@ -151,31 +151,31 @@ ConfigChecker::createKeyLocatorNameChecker(const BoostInfoTree& configSection)
     const BoostInfoTree& hyperRelation = *hyperRelationList[0];
 
     // Get k-regex.
-    const string* keyRegex = hyperRelation.getFirstValue("k-regex");
+    ptr_lib::shared_ptr<string> keyRegex = hyperRelation.getFirstValue("k-regex");
     if (!keyRegex)
       throw ValidatorConfigError
         ("Expected <checker.key-locator.hyper-relation.k-regex>");
 
     // Get k-expand.
-    const string* keyExpansion = hyperRelation.getFirstValue("k-expand");
+    ptr_lib::shared_ptr<string> keyExpansion = hyperRelation.getFirstValue("k-expand");
     if (!keyExpansion)
       throw ValidatorConfigError
         ("Expected <checker.key-locator.hyper-relation.k-expand");
 
     // Get h-relation.
-    const string* hyperRelationString = hyperRelation.getFirstValue("h-relation");
+    ptr_lib::shared_ptr<string> hyperRelationString = hyperRelation.getFirstValue("h-relation");
     if (!hyperRelationString)
       throw ValidatorConfigError
         ("Expected <checker.key-locator.hyper-relation.h-relation>");
 
     // Get p-regex.
-    const string* packetNameRegex = hyperRelation.getFirstValue("p-regex");
+    ptr_lib::shared_ptr<string> packetNameRegex = hyperRelation.getFirstValue("p-regex");
     if (!packetNameRegex)
       throw ValidatorConfigError
         ("Expected <checker.key-locator.hyper-relation.p-regex>");
 
     // Get p-expand.
-    const string* packetNameExpansion = hyperRelation.getFirstValue("p-expand");
+    ptr_lib::shared_ptr<string> packetNameExpansion = hyperRelation.getFirstValue("p-expand");
     if (!packetNameExpansion)
       throw ValidatorConfigError
         ("Expected <checker.key-locator.hyper-relation.p-expand>");

--- a/src/security/v2/validator-config/config-filter.cpp
+++ b/src/security/v2/validator-config/config-filter.cpp
@@ -67,7 +67,7 @@ ConfigFilter::match(bool isForInterest, const Name& packetName)
 ptr_lib::shared_ptr<ConfigFilter>
 ConfigFilter::create(const BoostInfoTree& configSection)
 {
-  const string* filterType = configSection.getFirstValue("type");
+  ptr_lib::shared_ptr<string> filterType = configSection.getFirstValue("type");
   if (!filterType)
     throw ValidatorConfigError("Expected <filter.type>");
 
@@ -80,13 +80,13 @@ ConfigFilter::create(const BoostInfoTree& configSection)
 ptr_lib::shared_ptr<ConfigFilter>
 ConfigFilter::createNameFilter(const BoostInfoTree& configSection)
 {
-  const string* nameUri = configSection.getFirstValue("name");
+  ptr_lib::shared_ptr<string> nameUri = configSection.getFirstValue("name");
   if (nameUri) {
     // Get the filter.name.
     Name name(*nameUri);
 
     // Get the filter.relation.
-    const string* relationValue = configSection.getFirstValue("relation");
+    ptr_lib::shared_ptr<string> relationValue = configSection.getFirstValue("relation");
     if (!relationValue)
       throw ValidatorConfigError("Expected <filter.relation>");
 
@@ -96,7 +96,7 @@ ConfigFilter::createNameFilter(const BoostInfoTree& configSection)
     return ptr_lib::make_shared<ConfigRelationNameFilter>(name, relation);
   }
 
-  const string* regexString = configSection.getFirstValue("regex");
+  ptr_lib::shared_ptr<string> regexString = configSection.getFirstValue("regex");
   if (regexString) {
     try {
       return ptr_lib::make_shared<ConfigRegexNameFilter>(*regexString);

--- a/src/security/v2/validator-config/config-rule.cpp
+++ b/src/security/v2/validator-config/config-rule.cpp
@@ -101,12 +101,12 @@ ptr_lib::shared_ptr<ConfigRule>
 ConfigRule::create(const BoostInfoTree& configSection)
 {
   // Get rule.id .
-  const string* ruleId = configSection.getFirstValue("id");
+  ptr_lib::shared_ptr<string> ruleId = configSection.getFirstValue("id");
   if (!ruleId)
     throw ValidatorConfigError("Expecting <rule.id>");
 
   // Get rule.for .
-  const string* usage = configSection.getFirstValue("for");
+  ptr_lib::shared_ptr<string> usage = configSection.getFirstValue("for");
   if (!usage)
     throw ValidatorConfigError("Expecting <rule.for> in rule: " + *ruleId);
 

--- a/src/sync/detail/invertible-bloom-lookup-table.cpp
+++ b/src/sync/detail/invertible-bloom-lookup-table.cpp
@@ -91,7 +91,7 @@ InvertibleBloomLookupTable::initialize(const Blob& encoding)
   if (3 * hashTable_.size() != values.size())
     throw runtime_error("The received Invertible Bloom Filter cannot be decoded");
 
-  for (size_t i = 0; i < hashTable_.size(); i++) {
+  for (size_t i = 0; i < hashTable_.size(); ++i) {
     HashTableEntry& entry = hashTable_.at(i);
     if (values[i * 3] != 0) {
       entry.count_ = values[i * 3];
@@ -148,7 +148,7 @@ InvertibleBloomLookupTable::difference
 
   ptr_lib::shared_ptr<InvertibleBloomLookupTable> result =
     ptr_lib::make_shared<InvertibleBloomLookupTable>(*this);
-  for (size_t i = 0; i < hashTable_.size(); i++) {
+  for (size_t i = 0; i < hashTable_.size(); ++i) {
     HashTableEntry& e1 = result->hashTable_.at(i);
     const HashTableEntry& e2 = other.hashTable_.at(i);
     e1.count_ -= e2.count_;
@@ -168,7 +168,7 @@ InvertibleBloomLookupTable::encode() const
 
   vector<uint8_t> table(tableSize);
 
-  for (size_t i = 0; i < nEntries; i++) {
+  for (size_t i = 0; i < nEntries; ++i) {
     const HashTableEntry& entry = hashTable_[i];
 
     // table[i*12],   table[i*12+1], table[i*12+2], table[i*12+3] --> hashTable[i].count_
@@ -204,7 +204,7 @@ InvertibleBloomLookupTable::equals(const InvertibleBloomLookupTable& other) cons
   if (iblt1HashTable.size() != iblt2HashTable.size())
     return false;
 
-  for (size_t i = 0; i < iblt1HashTable.size(); i++) {
+  for (size_t i = 0; i < iblt1HashTable.size(); ++i) {
     if (iblt1HashTable[i].count_ != iblt2HashTable[i].count_ ||
         iblt1HashTable[i].keySum_ != iblt2HashTable[i].keySum_ ||
         iblt1HashTable[i].keyCheck_ != iblt2HashTable[i].keyCheck_)
@@ -219,7 +219,7 @@ InvertibleBloomLookupTable::update(int plusOrMinus, uint32_t key)
 {
   size_t bucketsPerHash = hashTable_.size() / N_HASH;
 
-  for (size_t i = 0; i < N_HASH; i++) {
+  for (size_t i = 0; i < N_HASH; ++i) {
     size_t startEntry = i * bucketsPerHash;
     uint32_t h = CryptoLite::murmurHash3(i, key);
     HashTableEntry& entry = hashTable_.at(startEntry + (h % bucketsPerHash));

--- a/src/sync/digest-tree.cpp
+++ b/src/sync/digest-tree.cpp
@@ -164,7 +164,7 @@ DigestTree::Node::recomputeDigest()
 void
 DigestTree::Node::int32ToLittleEndian(uint32_t value, uint8_t* result)
 {
-  for (size_t i = 0; i < 4; i++) {
+  for (size_t i = 0; i < 4; ++i) {
     result[i] = value % 256;
     value = value / 256;
   }

--- a/src/util/boost-info-parser.hpp
+++ b/src/util/boost-info-parser.hpp
@@ -93,17 +93,16 @@ public:
   /**
    * Look up using the key and return string value of the first subtree.
    * @param key The key which may be a path separated with '/'.
-   * @return A pointer to the string value or 0 if not found.  Note that this
-   * pointer may no longer be valid after this BoostInfoTree is modified.
+   * @return A shared_ptr for the string value or null if not found.
    */
-  const std::string*
+  ptr_lib::shared_ptr<std::string>
   getFirstValue(const std::string& key) const
   {
     std::vector<const BoostInfoTree*> list = (*this)[key];
     if (list.size() >= 1)
-      return &list[0]->value_;
+      return ptr_lib::make_shared<std::string>(list[0]->value_);
     else
-      return 0;
+      return ptr_lib::shared_ptr<std::string>();
   }
 
   const std::string&

--- a/src/util/regex/ndn-regex-matcher-base.cpp
+++ b/src/util/regex/ndn-regex-matcher-base.cpp
@@ -74,7 +74,7 @@ NdnRegexMatcherBase::match(const Name& name, size_t offset, size_t len)
   matchResult_.clear();
 
   if (recursiveMatch(0, name, offset, len)) {
-    for (size_t i = offset; i < offset + len; i++)
+    for (size_t i = offset; i < offset + len; ++i)
       matchResult_.push_back(name.get(i));
     result = true;
   }


### PR DESCRIPTION
The recent CodeDX scan had High, Medium and Low severity findings. This pull request addresses the High and Medium findings. It has three commits:

- High: "Returning object that will be invalid when returning". Update BoostInfoTree::getFirstValue so that it return a null pointer or a shared_ptr with a copy of the string.
- Medium: "Prefix ++/-- operators should be preferred for non-primitive types". Change all for loops to use prefix increment.
- Medium: "Improper Restriction of Operations within the Bounds of a Memory Buffer". Updated Interest::toUri() to only call write if starting the write from bytes before the end of the buffer.