### PR TITLE
examples: Add cert-install.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2020-12-14)
+NDN-IND (2021-01-14)
 --------------------
 
 Changes
@@ -26,6 +26,7 @@ Changes
 * Move the instructions for RHEL 7 to the wiki.
 * Add support for Visual Studio. https://github.com/operantnetworks/ndn-ind/pull/17
 * In examples, add optional command-line arguments. https://github.com/operantnetworks/ndn-ind/pull/18
+* In examples, add cert-install .
 
 Bug fixes
 * In expressInterest, use the nonce in the Interest if provided.

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,7 @@ noinst_PROGRAMS = bin/test-access-manager bin/test-channel-discovery bin/test-ch
   bin/test-prefix-discovery \
   bin/test-publish-async-nfd bin/test-publish-async-nfd-lite bin/test-register-route \
   bin/test-secured-interest-responder bin/test-secured-interest-sender \
-  bin/test-sign-verify-data-hmac
+  bin/test-sign-verify-data-hmac bin/cert-install
 
 # Public C headers.
 # NOTE: If a new directory is added, then add it to ndn_ind_c_headers in include/Makefile.am.
@@ -588,6 +588,9 @@ bin_test_register_route_SOURCES = \
   examples/control-parameters.pb.cc examples/face-query-filter.pb.cc \
   examples/face-status.pb.cc examples/test-register-route.cpp
 bin_test_register_route_LDADD = libndn-ind.la
+
+bin_cert_install_SOURCES = examples/cert-install.cpp
+bin_cert_install_LDADD = libndn-ind.la
 
 # Unit tests
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -146,7 +146,8 @@ noinst_PROGRAMS = bin/test-access-manager$(EXEEXT) \
 	bin/test-register-route$(EXEEXT) \
 	bin/test-secured-interest-responder$(EXEEXT) \
 	bin/test-secured-interest-sender$(EXEEXT) \
-	bin/test-sign-verify-data-hmac$(EXEEXT)
+	bin/test-sign-verify-data-hmac$(EXEEXT) \
+	bin/cert-install$(EXEEXT)
 TESTS = $(check_PROGRAMS)
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -424,6 +425,9 @@ am_libndn_ind_la_OBJECTS = $(am__objects_2) $(am__objects_1) \
 	src/util/regex/ndn-regex-repeat-matcher.lo \
 	src/util/regex/ndn-regex-top-matcher.lo
 libndn_ind_la_OBJECTS = $(am_libndn_ind_la_OBJECTS)
+am_bin_cert_install_OBJECTS = examples/cert-install.$(OBJEXT)
+bin_cert_install_OBJECTS = $(am_bin_cert_install_OBJECTS)
+bin_cert_install_DEPENDENCIES = libndn-ind.la
 am_bin_test_access_manager_OBJECTS =  \
 	examples/test-access-manager.$(OBJEXT)
 bin_test_access_manager_OBJECTS =  \
@@ -776,6 +780,7 @@ am__depfiles_remade = contrib/apache/$(DEPDIR)/apr_base64.Plo \
 	contrib/murmur-hash/$(DEPDIR)/murmur-hash.Plo \
 	contrib/ndn-cxx/ndn-cxx/detail/$(DEPDIR)/cancel-handle.Plo \
 	contrib/ndn-cxx/ndn-cxx/util/$(DEPDIR)/scheduler.Plo \
+	examples/$(DEPDIR)/cert-install.Po \
 	examples/$(DEPDIR)/channel-status.pb.Po \
 	examples/$(DEPDIR)/chatbuf.pb.Po \
 	examples/$(DEPDIR)/control-parameters.pb.Po \
@@ -1100,7 +1105,8 @@ am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
 SOURCES = $(libndn_c_la_SOURCES) $(libndn_ind_tools_la_SOURCES) \
-	$(libndn_ind_la_SOURCES) $(bin_test_access_manager_SOURCES) \
+	$(libndn_ind_la_SOURCES) $(bin_cert_install_SOURCES) \
+	$(bin_test_access_manager_SOURCES) \
 	$(bin_test_channel_discovery_SOURCES) \
 	$(bin_test_chrono_chat_SOURCES) $(bin_test_custom_tpm_SOURCES) \
 	$(bin_test_echo_consumer_SOURCES) \
@@ -1155,7 +1161,8 @@ SOURCES = $(libndn_c_la_SOURCES) $(libndn_ind_tools_la_SOURCES) \
 	$(bin_unit_tests_test_validator_SOURCES) \
 	$(bin_unit_tests_test_validator_null_SOURCES)
 DIST_SOURCES = $(libndn_c_la_SOURCES) $(libndn_ind_tools_la_SOURCES) \
-	$(libndn_ind_la_SOURCES) $(bin_test_access_manager_SOURCES) \
+	$(libndn_ind_la_SOURCES) $(bin_cert_install_SOURCES) \
+	$(bin_test_access_manager_SOURCES) \
 	$(bin_test_channel_discovery_SOURCES) \
 	$(bin_test_chrono_chat_SOURCES) $(bin_test_custom_tpm_SOURCES) \
 	$(bin_test_echo_consumer_SOURCES) \
@@ -2187,6 +2194,8 @@ bin_test_register_route_SOURCES = \
   examples/face-status.pb.cc examples/test-register-route.cpp
 
 bin_test_register_route_LDADD = libndn-ind.la
+bin_cert_install_SOURCES = examples/cert-install.cpp
+bin_cert_install_LDADD = libndn-ind.la
 
 # Unit tests
 bin_unit_tests_test_access_manager_v2_SOURCES = tests/unit-tests/test-access-manager-v2.cpp \
@@ -3166,11 +3175,17 @@ examples/$(am__dirstamp):
 examples/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) examples/$(DEPDIR)
 	@: > examples/$(DEPDIR)/$(am__dirstamp)
-examples/test-access-manager.$(OBJEXT): examples/$(am__dirstamp) \
+examples/cert-install.$(OBJEXT): examples/$(am__dirstamp) \
 	examples/$(DEPDIR)/$(am__dirstamp)
 bin/$(am__dirstamp):
 	@$(MKDIR_P) bin
 	@: > bin/$(am__dirstamp)
+
+bin/cert-install$(EXEEXT): $(bin_cert_install_OBJECTS) $(bin_cert_install_DEPENDENCIES) $(EXTRA_bin_cert_install_DEPENDENCIES) bin/$(am__dirstamp)
+	@rm -f bin/cert-install$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(bin_cert_install_OBJECTS) $(bin_cert_install_LDADD) $(LIBS)
+examples/test-access-manager.$(OBJEXT): examples/$(am__dirstamp) \
+	examples/$(DEPDIR)/$(am__dirstamp)
 
 bin/test-access-manager$(EXEEXT): $(bin_test_access_manager_OBJECTS) $(bin_test_access_manager_DEPENDENCIES) $(EXTRA_bin_test_access_manager_DEPENDENCIES) bin/$(am__dirstamp)
 	@rm -f bin/test-access-manager$(EXEEXT)
@@ -3841,6 +3856,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/murmur-hash/$(DEPDIR)/murmur-hash.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/ndn-cxx/ndn-cxx/detail/$(DEPDIR)/cancel-handle.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/ndn-cxx/ndn-cxx/util/$(DEPDIR)/scheduler.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/cert-install.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/channel-status.pb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/chatbuf.pb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@examples/$(DEPDIR)/control-parameters.pb.Po@am__quote@ # am--include-marker
@@ -6264,6 +6280,7 @@ distclean: distclean-recursive
 	-rm -f contrib/murmur-hash/$(DEPDIR)/murmur-hash.Plo
 	-rm -f contrib/ndn-cxx/ndn-cxx/detail/$(DEPDIR)/cancel-handle.Plo
 	-rm -f contrib/ndn-cxx/ndn-cxx/util/$(DEPDIR)/scheduler.Plo
+	-rm -f examples/$(DEPDIR)/cert-install.Po
 	-rm -f examples/$(DEPDIR)/channel-status.pb.Po
 	-rm -f examples/$(DEPDIR)/chatbuf.pb.Po
 	-rm -f examples/$(DEPDIR)/control-parameters.pb.Po
@@ -6641,6 +6658,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f contrib/murmur-hash/$(DEPDIR)/murmur-hash.Plo
 	-rm -f contrib/ndn-cxx/ndn-cxx/detail/$(DEPDIR)/cancel-handle.Plo
 	-rm -f contrib/ndn-cxx/ndn-cxx/util/$(DEPDIR)/scheduler.Plo
+	-rm -f examples/$(DEPDIR)/cert-install.Po
 	-rm -f examples/$(DEPDIR)/channel-status.pb.Po
 	-rm -f examples/$(DEPDIR)/chatbuf.pb.Po
 	-rm -f examples/$(DEPDIR)/control-parameters.pb.Po

--- a/examples/cert-install.cpp
+++ b/examples/cert-install.cpp
@@ -1,0 +1,70 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
+/**
+ * Copyright (C) 2020-2021 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <ndn-ind/security/pib/pib-sqlite3.hpp>
+#include <ndn-ind/encoding/base64.hpp>
+
+using namespace std;
+using namespace ndn;
+
+/**
+ * Add a certificate from a base64 encoding file to the default PIB. If the PIB
+ * identity or key does not exist, create it. Make the added certificate the
+ * default certificate for the key. This utility is needed because
+ * "ndnsec cert-install" expects the identity with its private key to already
+ * exist.
+ */
+int main(int argc, char* argv[])
+{
+  string certificateFileName;
+  if (argc == 2)
+    certificateFileName = argv[1];
+  else {
+    cout << "usage:" << endl <<
+      "cert-install <base64-cert-file>" << endl;
+    return 1;
+  }
+
+  ifstream file(certificateFileName);
+  if (!file) {
+    cout << "Can't open file: " << certificateFileName << endl;
+    return 1;
+  }
+
+  stringstream certificateBase64;
+  while (file >> certificateBase64.rdbuf());
+
+  vector<uint8_t> certificateEncoding;
+  fromBase64(certificateBase64.str(), certificateEncoding);
+  CertificateV2 certificate;
+  certificate.wireDecode(certificateEncoding);
+
+  PibSqlite3 pibImpl;
+  pibImpl.addCertificate(certificate);
+  pibImpl.setDefaultCertificateOfKey(certificate.getKeyName(), certificate.getName());
+  cout << "Certificate has been added and set as default for the key:\n  " <<
+    certificate.getName() << endl;
+  
+  return 0;
+}


### PR DESCRIPTION
In examples, add the cert-install program which shows how to install a single certificate from a file into the local security database.