### PR TITLE
encoding: Change the default TlvWireFormat to v0.3.

### DIFF
--- a/include/ndn-ind/encoding/tlv-wire-format.hpp
+++ b/include/ndn-ind/encoding/tlv-wire-format.hpp
@@ -34,7 +34,7 @@
 #ifndef NDN_TLV_WIRE_FORMAT_HPP
 #define NDN_TLV_WIRE_FORMAT_HPP
 
-#include "tlv-0_2-wire-format.hpp"
+#include "tlv-0_3-wire-format.hpp"
 
 namespace ndn {
 
@@ -42,7 +42,7 @@ namespace ndn {
  * A TlvWireFormat extends WireFormat to override its virtual methods to implement encoding and decoding
  * using the preferred implementation of NDN-TLV.
  */
-class ndn_ind_dll TlvWireFormat : public Tlv0_2WireFormat {
+class ndn_ind_dll TlvWireFormat : public Tlv0_3WireFormat {
 public:
   /**
    * Get a singleton instance of a TlvWireFormat.  Assuming that the default wire format was set with


### PR DESCRIPTION
Starting with version 0.7.0, NFD drops support for TVL packet formats earlier than v0.3. For example, it will reject a request to register a prefix using the older format. So, this pull request changes the library's default wire encoding to v0.3.