### PR TITLE
Multiple access prefixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2021-01-14)
+NDN-IND (2021-02-03)
 --------------------
 
 Changes
@@ -13,8 +13,10 @@ Changes
   Change to use std::chrono. Remove unneeded CustomClock and system_clock wrapper.
   Renamed the ndn::time::steady_clock wrapper (only needed for macOS) to
   ndn::scheduler::MonotonicSteadyClock.
+* Changed the default wire format to TLV v0.3.
 * Add support for chacha20-Poly1305 in NAC. https://github.com/operantnetworks/ndn-ind/pull/7
 * Add support for a group content key (GCK) and secured interest in NAC.
+* Support multiple access managers in NAC. https://github.com/operantnetworks/ndn-ind/pull/25
 * In Interest, changed the MustBeFresh default value to false.
 * Added Tlv0_3WireFormat.
 * In Face, also check for a Unix socket at /var/tmp/nfd.sock .

--- a/examples/test-secured-interest-responder.cpp
+++ b/examples/test-secured-interest-responder.cpp
@@ -1,6 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /**
- * Copyright (C) 2020 Operant Networks, Incorporated.
+ * Copyright (C) 2020-2021 Operant Networks, Incorporated.
  * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -39,6 +39,7 @@
 #include <ndn-ind/encrypt/decryptor-v2.hpp>
 
 using namespace std;
+using namespace std::chrono;
 using namespace ndn;
 
 /**
@@ -229,8 +230,11 @@ static void
 usage()
 {
   cerr << "Usage: test-secured-interest-responder [options]\n"
-       << "  -a access-group-name The access group name as printed by test-access-manager. If omitted, use\n"
+       << "  -a access-group-name The access group name as printed by test-access-manager. You can specify\n"
+       << "                       this multiple times in order of priority of access managers. If omitted, use\n"
        << "                       <default-identity>/NAC/test-group where <default-identity> is the system default identity.\n"
+       << "  -c check-GCK-seconds The repeat interval in seconds to check if the access manager has a new GCK.\n"
+       << "                       If omitted, use 60 seconds.\n"
        << "  -n name-prefix       The name prefix for the message. If omitted, use /test-secured-interest\n"
        << "                       This must match the prefix for test-secured-interest-sender.\n"
        << "  -k                   Keep responding. If omitted, quit after one response\n"
@@ -240,7 +244,8 @@ usage()
 int
 main(int argc, char** argv)
 {
-  Name accessGroupName;
+  vector<Name> accessGroupNames;
+  seconds checkGckInterval(60);
   Name messagePrefix("/test-secured-interest");
 
   for (int i = 1; i < argc; ++i) {
@@ -252,7 +257,11 @@ main(int argc, char** argv)
       return 0;
     }
     else if (arg == "-a") {
-      accessGroupName = Name(value);
+      accessGroupNames.push_back(Name(value));
+      ++i;
+    }
+    else if (arg == "-c") {
+      checkGckInterval = seconds(atoi(value.c_str()));
       ++i;
     }
     else if (arg == "-n") {
@@ -285,25 +294,26 @@ main(int argc, char** argv)
     // In a production application, use a validator which has access to the
     // certificates of the access manager and the sender.
     auto validator = ptr_lib::make_shared<ValidatorNull>();
-    if (accessGroupName.size() == 0) {
+    if (accessGroupNames.size() == 0) {
       // Assume the access manager is the default identity on this computer.
       auto accessManagerName =
         systemKeyChain.getPib().getIdentity(systemKeyChain.getDefaultIdentity())->getName();
-      accessGroupName = Name(accessManagerName).append(Name("NAC/test-group"));
+      accessGroupNames.push_back(Name(accessManagerName).append(Name("NAC/test-group")));
     }
-    // Create the DecryptorV2 to decrypt the secured Interest.
-    auto decryptor = ptr_lib::make_shared<ndn::DecryptorV2>
-      (nacKeyChain->getPib().getIdentity(responderName)->getDefaultKey().get(),
-       validator.get(), nacKeyChain.get(), &face);
     // Create the EncryptorV2 to encrypt the reply Data packet.
     auto encryptor = ptr_lib::make_shared<EncryptorV2>
-      (accessGroupName,
+      (&accessGroupNames.front(), accessGroupNames.size(),
        [](auto errorCode, const std::string& message) {
          cout << "EncryptorV2 error: " << message << endl;
          isRunning = false;
        },
        nacKeyChain->getPib().getIdentity(responderName)->getDefaultKey().get(),
        validator.get(), nacKeyChain.get(), &face, ndn_EncryptAlgorithmType_AesCbc);
+    encryptor->setCheckForNewGckInterval(checkGckInterval);
+    // Create the DecryptorV2 to decrypt the secured Interest.
+    auto decryptor = ptr_lib::make_shared<ndn::DecryptorV2>
+      (nacKeyChain->getPib().getIdentity(responderName)->getDefaultKey().get(),
+       validator.get(), nacKeyChain.get(), &face);
 
     face.registerPrefix(
       messagePrefix,

--- a/examples/test-secured-interest-responder.cpp
+++ b/examples/test-secured-interest-responder.cpp
@@ -313,7 +313,7 @@ main(int argc, char** argv)
     // Create the DecryptorV2 to decrypt the secured Interest.
     auto decryptor = ptr_lib::make_shared<ndn::DecryptorV2>
       (nacKeyChain->getPib().getIdentity(responderName)->getDefaultKey().get(),
-       validator.get(), nacKeyChain.get(), &face);
+       validator.get(), nacKeyChain.get(), &face, encryptor.get());
 
     face.registerPrefix(
       messagePrefix,

--- a/examples/test-secured-interest-sender.cpp
+++ b/examples/test-secured-interest-sender.cpp
@@ -331,7 +331,7 @@ main(int argc, char** argv)
     // Create the DecryptorV2 to decrypt the reply Data packet.
     auto decryptor = ptr_lib::make_shared<ndn::DecryptorV2>
       (nacKeyChain->getPib().getIdentity(senderName)->getDefaultKey().get(),
-       validator.get(), nacKeyChain.get(), face.get());
+       validator.get(), nacKeyChain.get(), face.get(), encryptor.get());
 
     auto interest = ptr_lib::make_shared<Interest>(messagePrefix);
     commandInterestPreparer.prepareCommandInterestName(*interest);

--- a/examples/test-secured-interest-sender.cpp
+++ b/examples/test-secured-interest-sender.cpp
@@ -1,6 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /**
- * Copyright (C) 2020 Operant Networks, Incorporated.
+ * Copyright (C) 2020-2021 Operant Networks, Incorporated.
  * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,7 +21,8 @@
 
 /**
  * This example creates a secured interest with Name-based Access Control using
- * a group content key (GCK). It gets the GCK from the access manager and uses
+ * a group content key (GCK). It gets the GCK from the access manager (or from
+ * the first available in a prioritized list of access managers) and uses
  * it to encrypt a message which is sent in the Interest's ApplicationParameters
  * field. The interest is sent to the responder which decrypts the message,
  * creates a response message, encrypts it and sends a response Data packet.
@@ -227,8 +228,11 @@ static void
 usage()
 {
   cerr << "Usage: test-secured-interest-sender [options]\n"
-       << "  -a access-group-name The access group name as printed by test-access-manager. If omitted, use\n"
+       << "  -a access-group-name The access group name as printed by test-access-manager. You can specify\n"
+       << "                       this multiple times in order of priority of access managers. If omitted, use\n"
        << "                       <default-identity>/NAC/test-group where <default-identity> is the system default identity.\n"
+       << "  -c check-GCK-seconds The repeat interval in seconds to check if the access manager has a new GCK.\n"
+       << "                       If omitted, use 60 seconds.\n"
        << "  -n name-prefix       The name prefix for the message. If omitted, use /test-secured-interest\n"
        << "                       This must match the prefix for test-secured-interest-responder.\n"
        << "  -h host              If omitted or \"\", the default Face connects to the local forwarder\n"
@@ -240,7 +244,8 @@ usage()
 int
 main(int argc, char** argv)
 {
-  Name accessGroupName;
+  vector<Name> accessGroupNames;
+  seconds checkGckInterval(60);
   Name messagePrefix("/test-secured-interest");
   string host = "";
   int port = 6363;
@@ -254,7 +259,11 @@ main(int argc, char** argv)
       return 0;
     }
     else if (arg == "-a") {
-      accessGroupName = Name(value);
+      accessGroupNames.push_back(Name(value));
+      ++i;
+    }
+    else if (arg == "-c") {
+      checkGckInterval = seconds(atoi(value.c_str()));
       ++i;
     }
     else if (arg == "-n") {
@@ -303,21 +312,22 @@ main(int argc, char** argv)
     // In a production application, use a validator which has access to the
     // certificates of the access manager and the responder.
     auto validator = ptr_lib::make_shared<ValidatorNull>();
-    if (accessGroupName.size() == 0) {
+    if (accessGroupNames.size() == 0) {
       // Assume the access manager is the default identity on this computer.
       auto accessManagerName =
         systemKeyChain.getPib().getIdentity(systemKeyChain.getDefaultIdentity())->getName();
-      accessGroupName = Name(accessManagerName).append(Name("NAC/test-group"));
+      accessGroupNames.push_back(Name(accessManagerName).append(Name("NAC/test-group")));
     }
     // Create the EncryptorV2 to encrypt the secured interest.
     auto encryptor = ptr_lib::make_shared<EncryptorV2>
-      (accessGroupName,
+      (&accessGroupNames.front(), accessGroupNames.size(),
        [](auto errorCode, const std::string& message) {
          cout << "EncryptorV2 error: " << message << endl;
          isRunning = false;
        },
        nacKeyChain->getPib().getIdentity(senderName)->getDefaultKey().get(),
        validator.get(), nacKeyChain.get(), face.get(), ndn_EncryptAlgorithmType_AesCbc);
+    encryptor->setCheckForNewGckInterval(checkGckInterval);
     // Create the DecryptorV2 to decrypt the reply Data packet.
     auto decryptor = ptr_lib::make_shared<ndn::DecryptorV2>
       (nacKeyChain->getPib().getIdentity(senderName)->getDefaultKey().get(),

--- a/include/ndn-ind/encrypt/encryptor-v2.hpp
+++ b/include/ndn-ind/encrypt/encryptor-v2.hpp
@@ -577,14 +577,14 @@ private:
 
     /**
      * Decrypt the gckData fetched by fetchGck(), then copy it to ckBits_ and
-     * copy gckName to ckName_ . Then process pending decrypts.
+     * copy gckName to ckName_ . Then process pending encrypts.
      * @param gckName The Name that fetchGck() used to fetch.
      * @param gckData The GCK Data packet fetched by fetchGck().
      * @param onError On failure, this calls onError(errorCode, message)
      * where errorCode is from EncryptError::ErrorCode, and message is an error
      * string.
      */
-    void decryptGckAndProcessPendingDecrypts(
+    void decryptGckAndProcessPendingEncrypts(
       const Name& gckName, const Data& gckData,
       const EncryptError::OnError& onError);
 

--- a/src/encrypt/encryptor-v2.cpp
+++ b/src/encrypt/encryptor-v2.cpp
@@ -650,7 +650,7 @@ EncryptorV2::Impl::fetchGck(
         parent_->gckPendingInterestId_ = 0;
 
         // Leave isGckRetrievalInProgress_ true.
-        parent_->decryptGckAndProcessPendingDecrypts(gckName_, *ckData, onError_);
+        parent_->decryptGckAndProcessPendingEncrypts(gckName_, *ckData, onError_);
       } catch (const std::exception& ex) {
         onError_(EncryptError::ErrorCode::General,
           string("Error in EncryptorV2::fetchGck onData: ") + ex.what());
@@ -707,7 +707,7 @@ EncryptorV2::Impl::fetchGck(
 }
 
 void
-EncryptorV2::Impl::decryptGckAndProcessPendingDecrypts(
+EncryptorV2::Impl::decryptGckAndProcessPendingEncrypts(
   const Name& gckName, const Data& gckData, const EncryptError::OnError& onError)
 {
   // This is only called from fetchGck, so isGckRetrievalInProgress_ is true.

--- a/tests/unit-tests/test-encryptor-v2.cpp
+++ b/tests/unit-tests/test-encryptor-v2.cpp
@@ -1,6 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /**
- * Copyright (C) 2020 Operant Networks, Incorporated.
+ * Copyright (C) 2020-2021 Operant Networks, Incorporated.
  * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This works is based substantially on previous work as listed below:
@@ -107,8 +107,8 @@ public:
 
 TEST_F(TestEncryptorV2, EncryptAndPublishCk)
 {
-  fixture_->encryptor_->impl_->kekData_.reset();
-  ASSERT_EQ(false, fixture_->encryptor_->impl_->isKekRetrievalInProgress_);
+  fixture_->encryptor_->impl_->keyManagers_[0]->kekData_.reset();
+  ASSERT_EQ(false, fixture_->encryptor_->impl_->keyManagers_[0]->isKekRetrievalInProgress_);
   fixture_->encryptor_->regenerateCk();
   // Unlike the ndn-group-encrypt unit tests, we don't check
   // isKekRetrievalInProgress_ true because we use a synchronous face which
@@ -149,7 +149,7 @@ TEST_F(TestEncryptorV2, EncryptAndPublishCk)
   Name extractedKek = ckName.getSubName(6);
   ASSERT_TRUE(extractedKek.equals(kekData->getName()));
 
-  ASSERT_EQ(false, fixture_->encryptor_->impl_->isKekRetrievalInProgress_);
+  ASSERT_EQ(false, fixture_->encryptor_->impl_->keyManagers_[0]->isKekRetrievalInProgress_);
 }
 
 TEST_F(TestEncryptorV2, KekRetrievalFailure)
@@ -210,8 +210,8 @@ TEST_F(TestEncryptorV2, EnumerateDataFromInMemoryStorage)
   ASSERT_EQ(3, fixture_->encryptor_->size());
   int nCk = 0;
   for (map<Name, ptr_lib::shared_ptr<Data> >::iterator i =
-        fixture_->encryptor_->impl_->storage_.cache_.begin();
-       i != fixture_->encryptor_->impl_->storage_.cache_.end(); ++i) {
+        fixture_->encryptor_->impl_->keyManagers_[0]->storage_.cache_.begin();
+       i != fixture_->encryptor_->impl_->keyManagers_[0]->storage_.cache_.end(); ++i) {
     if (i->second->getName().getPrefix(4).equals(Name("/some/ck/prefix/CK")))
       ++nCk;
   }


### PR DESCRIPTION
This pull request updates `EncryptorV2` to support fetching the GCK from multiple access managers in a prioritized list. If a higher-priority access managers does not respond, then use the next responding access manager on the list. (If the `EncrpytorV2` is created with only one access manager, then the behavior is unchanged.)

This pull request has six commits. The first commit is a minor correction to `EncryptorV2`. The private method `decryptGckAndProcessPendingDecrypts` should be named `decryptGckAndProcessPendingEncrypts`.

The second commit re-arranges code in `EncryptorV2`, keeping the same functionality. We create an inner class `KeyManager` which keeps the details of fetching the content key for a particular access manager. The main class adds a list of `keyManagers_` which initially only has one member and calls its methods, keeping the same functionality. This commit is meant to make it easy to see that it only rearranges code.

The third commit redistributes the responsibility for processing pending encrypt operations, keeping the same functionality. When `encrypt` is called, if a content key has not been fetched from the access manager, then it sends an interest to fetch it and the data is added to a pending encrypt list. When the content key is finally fetched, it is used to process the pending encrypt operations. This pull request moves that processing to a new method [processPendingEncrypts](https://github.com/operantnetworks/ndn-ind/blob/42d5ec1ade45f85e2987aeee1a38c9f436820249/include/ndn-ind/encrypt/encryptor-v2.hpp#L690-L695). It also refactors the `encrypt` method to move the code for checking if a content key is needed into a new method [isKeyReady](https://github.com/operantnetworks/ndn-ind/blob/42d5ec1ade45f85e2987aeee1a38c9f436820249/include/ndn-ind/encrypt/encryptor-v2.hpp#L586-L593). Also, since events like interest timeout happen in callbacks while the main encrypt operations can proceed, it doesn't make sense to use the onError callback. So, this commit changes to call `_LOG_ERROR` when errors are encountered while attempting to fetch a key. Again, this commit is meant to make it easy to see that it only rearranges code without changing functionality.

The fourth commit adds the logic to handle multiple access managers. We add a new [EncryptorV2 constructor](https://github.com/operantnetworks/ndn-ind/blob/ac0c3a6f1b98afb74daf5e18624bade5252708e7/include/ndn-ind/encrypt/encryptor-v2.hpp#L176-L177) which takes a list of name prefixes for each access manager. The constructor creates a `KeyManager` for each one. The `encrypt` method calls the `isKeyReady` method of each `KeyManger` and uses the encryption key of the first one which returns true. In the `KeyManager`, we add a flag `accessManagerIsResponding_` which is set true each time it receives a Data packet and false each time it receives an interest timeout or network nack. This is used in `isKeyReady` to return false if an access manager is not responding, so that `encrypt` will try another access manager. The main change is in the logic for when a new GCK is received. If we are using multiple access managers, then we [temporarily store received key](https://github.com/operantnetworks/ndn-ind/blob/ac0c3a6f1b98afb74daf5e18624bade5252708e7/src/encrypt/encryptor-v2.cpp#L902-L913) as the "next GCK", but do not use it right away. Instead we wait until the next response from the access manager to [check if enough time has passed](https://github.com/operantnetworks/ndn-ind/blob/ac0c3a6f1b98afb74daf5e18624bade5252708e7/src/encrypt/encryptor-v2.cpp#L670-L708) for the other nodes to have fetched the same GCK, in which case it is set as the current content key for encryption.

The fifth commit updates the example programs test-secured-interest-sender and test-secured-interest-responder to allow multiple `-a` parameters in the command line arguments, to specify multiple access managers. We also add the optional command-line parameter `-c` to specify the interval to check the access managers for new keys. (The default is 60 seconds.) We also update test-access-manager to add the optional command-line parameter `-r` to specify the interval for refreshing the GCK.

Finally, the sixth commit updates `EncryptorV2` to keep a cache of each GCK that it has fetched and to add the public method [getContentKey](https://github.com/operantnetworks/ndn-ind/blob/37331aca9eba664dc277ba8307ce004bab2bfdb4/include/ndn-ind/encrypt/encryptor-v2.hpp#L405-L412) to get a key from the cache by name. We update the `DecryptorV2` constructor to take an `EncryptorV2` object as an [optional parameter contentKeyCache](https://github.com/operantnetworks/ndn-ind/blob/37331aca9eba664dc277ba8307ce004bab2bfdb4/include/ndn-ind/encrypt/decryptor-v2.hpp#L66-L67). We update the `decrypt` method to call the `EncryptorV2` `getContentKey` to check if has already fetched the GCK needed for decryption, in which case it doesn't need to fetch it. This also gives `getContentKey` a chance to send requests to its access managers to check if they have a new GCK. And we update the `DecryptorV2` object in the example programs test-secured-interest-sender and test-secured-interest-responder to use this functionality.