### PR TITLE
Resolve security scan findings

### DIFF
--- a/src/security/certificate/certificate.cpp
+++ b/src/security/certificate/certificate.cpp
@@ -205,7 +205,7 @@ Certificate::printCertificate(ostream& os) const
 
   os << "Subject Description:" << endl;
   vector<CertificateSubjectDescription>::const_iterator it = subjectDescriptionList_.begin();
-  for(; it < subjectDescriptionList_.end(); it++)
+  for(; it < subjectDescriptionList_.end(); ++it)
     os << "  " << it->getOidString() << ": " << it->getValue() << endl;
 
   os << "Public key bits:" << endl;

--- a/src/transport/async-socket-transport.hpp
+++ b/src/transport/async-socket-transport.hpp
@@ -128,6 +128,7 @@ private:
     : ioService_(ioService), socket_(new typename AsioProtocol::socket(ioService)),
       elementBuffer_(new DynamicUInt8Vector(1000)), isConnected_(false)
     {
+      ndn_memset((uint8_t *)&receiveBuffer_, 0, sizeof(receiveBuffer_));
       ndn_ElementReader_initialize
         (&elementReader_, 0, elementBuffer_.get(), readRawPackets);
     }

--- a/src/util/regex/ndn-regex-backref-matcher.hpp
+++ b/src/util/regex/ndn-regex-backref-matcher.hpp
@@ -44,7 +44,7 @@ public:
   lateCompile() { compile(); }
 
 protected:
-  virtual void
+  void
   compile();
 };
 

--- a/src/util/regex/ndn-regex-component-matcher.hpp
+++ b/src/util/regex/ndn-regex-component-matcher.hpp
@@ -56,7 +56,7 @@ protected:
   /**
    * Compile the regular expression to generate more matchers when necessary.
    */
-  virtual void
+  void
   compile();
 
 private:

--- a/src/util/regex/ndn-regex-component-set-matcher.hpp
+++ b/src/util/regex/ndn-regex-component-set-matcher.hpp
@@ -54,7 +54,7 @@ protected:
   /**
    * Compile the regular expression to generate more matchers when necessary.
    */
-  virtual void
+  void
   compile();
 
 private:

--- a/src/util/regex/ndn-regex-matcher-base.hpp
+++ b/src/util/regex/ndn-regex-matcher-base.hpp
@@ -130,13 +130,6 @@ public:
   const std::string&
   getExpr() const { return expr_; }
 
-protected:
-  /**
-   * Compile the regular expression to generate more matchers when necessary.
-   */
-  virtual void
-  compile() = 0;
-
 private:
   bool
   recursiveMatch(size_t matcherNo, const Name& name, size_t offset, size_t len);

--- a/src/util/regex/ndn-regex-pattern-list-matcher.hpp
+++ b/src/util/regex/ndn-regex-pattern-list-matcher.hpp
@@ -43,7 +43,7 @@ public:
   ~NdnRegexPatternListMatcher();
 
 protected:
-  virtual void
+  void
   compile();
 
 private:

--- a/src/util/regex/ndn-regex-pseudo-matcher.hpp
+++ b/src/util/regex/ndn-regex-pseudo-matcher.hpp
@@ -37,7 +37,7 @@ public:
   virtual
   ~NdnRegexPseudoMatcher();
 
-  virtual void
+  void
   compile();
 
   void

--- a/src/util/regex/ndn-regex-repeat-matcher.hpp
+++ b/src/util/regex/ndn-regex-repeat-matcher.hpp
@@ -49,7 +49,7 @@ protected:
   /**
    * Compile the regular expression to generate more matchers when necessary.
    */
-  virtual void
+  void
   compile();
 
 private:

--- a/src/util/regex/ndn-regex-top-matcher.cpp
+++ b/src/util/regex/ndn-regex-top-matcher.cpp
@@ -47,10 +47,10 @@ namespace ndn {
 
 NdnRegexTopMatcher::NdnRegexTopMatcher(const string& expr, const string& expand)
 : NdnRegexMatcherBase(expr, NDN_REGEX_EXPR_TOP), expand_(expand),
+  primaryBackrefManager_(ptr_lib::make_shared<NdnRegexBackrefManager>()),
+  secondaryBackrefManager_(ptr_lib::make_shared<NdnRegexBackrefManager>()),
   isSecondaryUsed_(false)
 {
-  primaryBackrefManager_ = ptr_lib::make_shared<NdnRegexBackrefManager>();
-  secondaryBackrefManager_ = ptr_lib::make_shared<NdnRegexBackrefManager>();
   compile();
 }
 

--- a/src/util/regex/ndn-regex-top-matcher.hpp
+++ b/src/util/regex/ndn-regex-top-matcher.hpp
@@ -53,7 +53,7 @@ public:
   fromName(const Name& name, bool hasAnchor=false);
 
 protected:
-  virtual void
+  void
   compile();
 
 private:


### PR DESCRIPTION
This pull request resolves 9 medium-severity security findings in a code scan. This pull request has 4 commits.

The first commit resolves 2 findings for "All member variables are called consecutively in the order the variables are declared" by setting `primaryBackrefManager_` and `secondaryBackrefManager_` in the constructor's initialization list instead of the body of the constructor.

The second commit resolves 5 findings for "Virtual function is called from constructor". The base class `NdnRegexMatcherBase` declares the pure virtual method `compile`. The derived classes override it, but also call it from the constructor which can have undefined initialization. This code was imported as-is from ndn-cxx. It appears that the method `compile` does not need to be virtual. So this commit resolves the finding by making it a non-virtual method. For confirmation from the authors of the original repository, I created the issue https://redmine.named-data.net/issues/5144 .

The third commit resolves 1 finding for "Prefix ++/-- operators should be preferred for non-primitive types" by changing `it++` to `++it` as suggested. (This is what we normally do in the code.)

Finally, the fourth commit resolves 1 finding for "Member variable is not initialized in the constructor." The variable `AsyncSocketTransport::Impl::receiveBuffer_` is a persistent buffer for reading bytes from the socket. It doesn't really need to be initialized in the constructor, but it doesn't hurt. This commit adds a call to memset to initialize it.