### PR TITLE
In Blob, add the default assignment operator

### DIFF
--- a/include/ndn-ind/util/blob.hpp
+++ b/include/ndn-ind/util/blob.hpp
@@ -117,6 +117,8 @@ public:
   {
   }
 
+  Blob& operator=(const Blob& blob) = default;
+
   /**
    * Create a new Blob to point to an existing byte array. IMPORTANT: If copy is
    * false, after calling this constructor, if you keep a pointer to the array


### PR DESCRIPTION
In Blob, specify the assignment operator to get rid of compiler warnings.

    Blob& operator=(const Blob& blob) = default;