### PR TITLE
GenericSignature: In the constructor, put initializers in the same order as declared

### DIFF
--- a/include/ndn-ind/generic-signature.hpp
+++ b/include/ndn-ind/generic-signature.hpp
@@ -50,8 +50,8 @@ public:
    * Create a new GenericSignature with default values.
    */
   GenericSignature()
-  : changeCount_(0),
-    typeCode_(-1)
+  : typeCode_(-1),
+    changeCount_(0)
   {
   }
 


### PR DESCRIPTION
In GenericSignature, the class variables `typeCode_` and `changeCount_` are [declared in that order](https://github.com/operantnetworks/ndn-ind/blob/2047f62f85e9580767b712a487154fa131375a8c/include/ndn-ind/generic-signature.hpp#L155-L156). But in the constructor, they are initialized in the reverse order, and some compilers issue a warning. This pull request updates the constructor to initialize in the same order as declared.