### PR TITLE
Add ValidityPeriod to DigestSha256Signature and GenericSignature

### DIFF
--- a/include/ndn-ind/digest-sha256-signature.hpp
+++ b/include/ndn-ind/digest-sha256-signature.hpp
@@ -35,6 +35,8 @@
 #define NDN_DIGEST_SHA256_SIGNATURE_HPP
 
 #include "signature.hpp"
+#include "security/validity-period.hpp"
+#include "util/change-counter.hpp"
 
 namespace ndn {
 
@@ -83,11 +85,36 @@ public:
   getSignature() const;
 
   /**
+   * Get the validity period.
+   * @return The validity period.
+   */
+  const ValidityPeriod&
+  getValidityPeriod() const { return validityPeriod_.get(); }
+
+  /**
+   * Get the validity period.
+   * @return The validity period.
+   */
+  ValidityPeriod&
+  getValidityPeriod() { return validityPeriod_.get(); }
+
+  /**
    * Set the signature bytes to the given value.
    * @param signature A Blob with the signature bytes.
    */
   virtual void
   setSignature(const Blob& signature);
+
+  /**
+   * Set the validity period to a copy of the given ValidityPeriod.
+   * @param validityPeriod The ValidityPeriod which is copied.
+   */
+  void
+  setValidityPeriod(const ValidityPeriod& validityPeriod)
+  {
+    validityPeriod_.set(validityPeriod);
+    ++changeCount_;
+  }
 
   /**
    * Clear all the fields.
@@ -96,6 +123,7 @@ public:
   clear()
   {
     signature_.reset();
+    validityPeriod_.get().clear();
     ++changeCount_;
   }
 
@@ -108,6 +136,7 @@ public:
 
 private:
   Blob signature_;
+  ChangeCounter<ValidityPeriod> validityPeriod_;
   uint64_t changeCount_;
 };
 

--- a/include/ndn-ind/generic-signature.hpp
+++ b/include/ndn-ind/generic-signature.hpp
@@ -35,6 +35,8 @@
 #define NDN_GENERIC_SIGNATURE_HPP
 
 #include "signature.hpp"
+#include "security/validity-period.hpp"
+#include "util/change-counter.hpp"
 
 namespace ndn {
 
@@ -90,6 +92,20 @@ public:
   getSignatureInfoEncoding() const { return signatureInfoEncoding_; }
 
   /**
+   * Get the validity period.
+   * @return The validity period.
+   */
+  const ValidityPeriod&
+  getValidityPeriod() const { return validityPeriod_.get(); }
+
+  /**
+   * Get the validity period.
+   * @return The validity period.
+   */
+  ValidityPeriod&
+  getValidityPeriod() { return validityPeriod_.get(); }
+
+  /**
    * Set the bytes of the entire signature info encoding (including the type
    * code).
    * @param signatureInfoEncoding A Blob with the encoding bytes.
@@ -121,6 +137,17 @@ public:
   setSignature(const Blob& signature);
 
   /**
+   * Set the validity period to a copy of the given ValidityPeriod.
+   * @param validityPeriod The ValidityPeriod which is copied.
+   */
+  void
+  setValidityPeriod(const ValidityPeriod& validityPeriod)
+  {
+    validityPeriod_.set(validityPeriod);
+    ++changeCount_;
+  }
+
+  /**
    * Get the type code of the signature type. When wire decode calls
    * setSignatureInfoEncoding, it sets the type code. Note that the type code
    * is ignored during wire encode, which simply uses getSignatureInfoEncoding()
@@ -138,6 +165,7 @@ public:
   {
     signature_.reset();
     signatureInfoEncoding_.reset();
+    validityPeriod_.get().clear();
     typeCode_ = -1;
     ++changeCount_;
   }
@@ -152,6 +180,7 @@ public:
 private:
   Blob signature_;
   Blob signatureInfoEncoding_;
+  ChangeCounter<ValidityPeriod> validityPeriod_;
   int typeCode_;
   uint64_t changeCount_;
 };

--- a/src/digest-sha256-signature.cpp
+++ b/src/digest-sha256-signature.cpp
@@ -65,6 +65,7 @@ DigestSha256Signature::get(SignatureLite& signatureLite) const
 
   signatureLite.setType(ndn_SignatureType_DigestSha256Signature);
   signatureLite.setSignature(signature_);
+  validityPeriod_.get().get(signatureLite.getValidityPeriod());
 }
 
 void
@@ -75,11 +76,18 @@ DigestSha256Signature::set(const SignatureLite& signatureLite)
     throw runtime_error("signatureLite is not the expected type DigestSha256Signature");
 
   setSignature(Blob(signatureLite.getSignature()));
+  validityPeriod_.get().set(signatureLite.getValidityPeriod());
 }
 
 uint64_t
 DigestSha256Signature::getChangeCount() const
 {
+  bool changed = validityPeriod_.checkChanged();
+  if (changed)
+    // A child object has changed, so update the change count.
+    // This method can be called on a const object, but we want to be able to update the changeCount_.
+    ++const_cast<DigestSha256Signature*>(this)->changeCount_;
+
   return changeCount_;
 }
 

--- a/src/generic-signature.cpp
+++ b/src/generic-signature.cpp
@@ -84,6 +84,12 @@ GenericSignature::set(const SignatureLite& signatureLite)
 uint64_t
 GenericSignature::getChangeCount() const
 {
+  bool changed = validityPeriod_.checkChanged();
+  if (changed)
+    // A child object has changed, so update the change count.
+    // This method can be called on a const object, but we want to be able to update the changeCount_.
+    ++const_cast<GenericSignature*>(this)->changeCount_;
+
   return changeCount_;
 }
 

--- a/src/security/validity-period.cpp
+++ b/src/security/validity-period.cpp
@@ -36,6 +36,8 @@
 #include <stdexcept>
 #include <ndn-ind/sha256-with-ecdsa-signature.hpp>
 #include <ndn-ind/sha256-with-rsa-signature.hpp>
+#include <ndn-ind/digest-sha256-signature.hpp>
+#include <ndn-ind/generic-signature.hpp>
 #include <ndn-ind/security/validity-period.hpp>
 
 using namespace std;
@@ -55,6 +57,8 @@ bool
 ValidityPeriod::canGetFromSignature(const Signature* signature)
 {
   return dynamic_cast<const Sha256WithRsaSignature *>(signature) ||
+         dynamic_cast<const DigestSha256Signature *>(signature) ||
+         dynamic_cast<const GenericSignature *>(signature) ||
          dynamic_cast<const Sha256WithEcdsaSignature *>(signature);
 }
 
@@ -70,6 +74,18 @@ ValidityPeriod::getFromSignature(Signature* signature)
   {
     Sha256WithEcdsaSignature *castSignature =
       dynamic_cast<Sha256WithEcdsaSignature *>(signature);
+    if (castSignature)
+      return castSignature->getValidityPeriod();
+  }
+  {
+    DigestSha256Signature *castSignature =
+      dynamic_cast<DigestSha256Signature *>(signature);
+    if (castSignature)
+      return castSignature->getValidityPeriod();
+  }
+  {
+    GenericSignature *castSignature =
+      dynamic_cast<GenericSignature *>(signature);
     if (castSignature)
       return castSignature->getValidityPeriod();
   }


### PR DESCRIPTION
This pull request has two commits. The first commit adds ValidityPeriod to `DigestSha256Signature` and `GenericSignature`, including the "getter" and "setter" method. For `DigestSha256Signature`,  the low-level tlv-signature-info.c is also updated to encode and decode the validity period in the TLV DigestSha256 signature info.

The second commit updates the `DigestSha256Signature` methods `get` and `set` which transfer fields between the C++ managed-memory object`DigestSha256Signature` and the non-managed-memory `SignatureLite` struct which is used by the low-level TLV encoder. The validity period fields must also be transferred. This commit also updates the `DigestSha256Signature` method `getChangeCount` to mark the object as changed if its `ValidityPeriod` is changed. (A change means that the cached TLV encoding must be re computed).