### PR TITLE
Add MicroForwarder

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-NDN-IND (2021-02-03)
+NDN-IND (2021-03-07)
 --------------------
 
 Changes
@@ -24,6 +24,7 @@ Changes
 * Remove obsolete Name-based Access Control v1. (Keep v2.)
 * PIB and TPM: Change system() to mkdir() or create_directories(). https://github.com/operantnetworks/ndn-ind/pull/15
 * In Transport, added readRawPackets to handle raw packets. https://github.com/operantnetworks/ndn-ind/pull/16
+* In tools, added MicroForwarder.
 * In examples and unit tests, use the default Face which doesn't require TCP.
 * Move the instructions for RHEL 7 to the wiki.
 * Add support for Visual Studio. https://github.com/operantnetworks/ndn-ind/pull/17

--- a/Makefile.am
+++ b/Makefile.am
@@ -266,6 +266,8 @@ ndn_ind_cpp_headers = \
 # Public ndn-ind-tools C++ headers.
 # NOTE: If a new directory is added, then add it to ndn_ind_tools_cpp_headers in include/Makefile.am.
 ndn_ind_tools_cpp_headers = \
+  include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp \
+  include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp \
   include/ndn-ind-tools/usersync/channel-discovery.hpp \
   include/ndn-ind-tools/usersync/content-meta-info.hpp \
   include/ndn-ind-tools/usersync/generalized-content.hpp \
@@ -506,6 +508,8 @@ libndn_ind_la_SOURCES = ${libndn_c_la_SOURCES} ${ndn_ind_cpp_headers} \
 
 # The ndn-ind-tools library.
 libndn_ind_tools_la_SOURCES = ${ndn_ind_tools_cpp_headers} ${ndn_ind_cpp_headers} \
+  tools/micro-forwarder/micro-forwarder.cpp \
+  tools/micro-forwarder/micro-forwarder-transport.cpp \
   tools/usersync/content-meta-info.pb.cc \
   tools/usersync/channel-discovery.cpp \
   tools/usersync/content-meta-info.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -159,6 +159,7 @@ ndn_ind_cpp_headers = \
   include/ndn-ind/lite/registration-options-lite.hpp \
   include/ndn-ind/lite/signature-lite.hpp \
   include/ndn-ind/lite/encoding/element-listener-lite.hpp \
+  include/ndn-ind/lite/encoding/element-reader-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_1_1-wire-format-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_2-wire-format-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_3-wire-format-lite.hpp \
@@ -388,6 +389,7 @@ libndn_ind_la_SOURCES = ${libndn_c_la_SOURCES} ${ndn_ind_cpp_headers} \
   src/lite/registration-options-lite.cpp \
   src/lite/signature-lite.cpp \
   src/lite/encoding/element-listener-lite.cpp \
+  src/lite/encoding/element-reader-lite.cpp \
   src/lite/encoding/tlv-0_2-wire-format-lite.cpp \
   src/lite/encoding/tlv-0_3-wire-format-lite.cpp \
   src/lite/encrypt/encrypted-content-lite.cpp \

--- a/Makefile.in
+++ b/Makefile.in
@@ -252,6 +252,8 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 libndn_ind_tools_la_DEPENDENCIES = libndn-ind.la
 am_libndn_ind_tools_la_OBJECTS = $(am__objects_1) $(am__objects_1) \
+	tools/micro-forwarder/micro-forwarder.lo \
+	tools/micro-forwarder/micro-forwarder-transport.lo \
 	tools/usersync/content-meta-info.pb.lo \
 	tools/usersync/channel-discovery.lo \
 	tools/usersync/content-meta-info.lo \
@@ -1064,6 +1066,8 @@ am__depfiles_remade = contrib/apache/$(DEPDIR)/apr_base64.Plo \
 	tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator-validator-fixture.Po \
 	tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-identity-management-fixture.Po \
 	tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-test-validator-null.Po \
+	tools/micro-forwarder/$(DEPDIR)/micro-forwarder-transport.Plo \
+	tools/micro-forwarder/$(DEPDIR)/micro-forwarder.Plo \
 	tools/usersync/$(DEPDIR)/channel-discovery.Plo \
 	tools/usersync/$(DEPDIR)/content-meta-info.Plo \
 	tools/usersync/$(DEPDIR)/content-meta-info.pb.Plo \
@@ -1895,6 +1899,8 @@ ndn_ind_cpp_headers = \
 # Public ndn-ind-tools C++ headers.
 # NOTE: If a new directory is added, then add it to ndn_ind_tools_cpp_headers in include/Makefile.am.
 ndn_ind_tools_cpp_headers = \
+  include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp \
+  include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp \
   include/ndn-ind-tools/usersync/channel-discovery.hpp \
   include/ndn-ind-tools/usersync/content-meta-info.hpp \
   include/ndn-ind-tools/usersync/generalized-content.hpp \
@@ -2138,6 +2144,8 @@ libndn_ind_la_SOURCES = ${libndn_c_la_SOURCES} ${ndn_ind_cpp_headers} \
 
 # The ndn-ind-tools library.
 libndn_ind_tools_la_SOURCES = ${ndn_ind_tools_cpp_headers} ${ndn_ind_cpp_headers} \
+  tools/micro-forwarder/micro-forwarder.cpp \
+  tools/micro-forwarder/micro-forwarder-transport.cpp \
   tools/usersync/content-meta-info.pb.cc \
   tools/usersync/channel-discovery.cpp \
   tools/usersync/content-meta-info.cpp \
@@ -2585,6 +2593,18 @@ src/c/util/time.lo: src/c/util/$(am__dirstamp) \
 
 libndn-c.la: $(libndn_c_la_OBJECTS) $(libndn_c_la_DEPENDENCIES) $(EXTRA_libndn_c_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(LINK) -rpath $(libdir) $(libndn_c_la_OBJECTS) $(libndn_c_la_LIBADD) $(LIBS)
+tools/micro-forwarder/$(am__dirstamp):
+	@$(MKDIR_P) tools/micro-forwarder
+	@: > tools/micro-forwarder/$(am__dirstamp)
+tools/micro-forwarder/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) tools/micro-forwarder/$(DEPDIR)
+	@: > tools/micro-forwarder/$(DEPDIR)/$(am__dirstamp)
+tools/micro-forwarder/micro-forwarder.lo:  \
+	tools/micro-forwarder/$(am__dirstamp) \
+	tools/micro-forwarder/$(DEPDIR)/$(am__dirstamp)
+tools/micro-forwarder/micro-forwarder-transport.lo:  \
+	tools/micro-forwarder/$(am__dirstamp) \
+	tools/micro-forwarder/$(DEPDIR)/$(am__dirstamp)
 tools/usersync/$(am__dirstamp):
 	@$(MKDIR_P) tools/usersync
 	@: > tools/usersync/$(am__dirstamp)
@@ -3823,6 +3843,8 @@ mostlyclean-compile:
 	-rm -f src/util/regex/*.$(OBJEXT)
 	-rm -f src/util/regex/*.lo
 	-rm -f tests/unit-tests/*.$(OBJEXT)
+	-rm -f tools/micro-forwarder/*.$(OBJEXT)
+	-rm -f tools/micro-forwarder/*.lo
 	-rm -f tools/usersync/*.$(OBJEXT)
 	-rm -f tools/usersync/*.lo
 
@@ -4156,6 +4178,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator-validator-fixture.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-identity-management-fixture.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-test-validator-null.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tools/micro-forwarder/$(DEPDIR)/micro-forwarder-transport.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tools/micro-forwarder/$(DEPDIR)/micro-forwarder.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tools/usersync/$(DEPDIR)/channel-discovery.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tools/usersync/$(DEPDIR)/content-meta-info.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tools/usersync/$(DEPDIR)/content-meta-info.pb.Plo@am__quote@ # am--include-marker
@@ -5420,6 +5444,7 @@ clean-libtool:
 	-rm -rf src/transport/.libs src/transport/_libs
 	-rm -rf src/util/.libs src/util/_libs
 	-rm -rf src/util/regex/.libs src/util/regex/_libs
+	-rm -rf tools/micro-forwarder/.libs tools/micro-forwarder/_libs
 	-rm -rf tools/usersync/.libs tools/usersync/_libs
 
 distclean-libtool:
@@ -6241,6 +6266,8 @@ distclean-generic:
 	-rm -f src/util/regex/$(am__dirstamp)
 	-rm -f tests/unit-tests/$(DEPDIR)/$(am__dirstamp)
 	-rm -f tests/unit-tests/$(am__dirstamp)
+	-rm -f tools/micro-forwarder/$(DEPDIR)/$(am__dirstamp)
+	-rm -f tools/micro-forwarder/$(am__dirstamp)
 	-rm -f tools/usersync/$(DEPDIR)/$(am__dirstamp)
 	-rm -f tools/usersync/$(am__dirstamp)
 
@@ -6581,6 +6608,8 @@ distclean: distclean-recursive
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator-validator-fixture.Po
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-identity-management-fixture.Po
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-test-validator-null.Po
+	-rm -f tools/micro-forwarder/$(DEPDIR)/micro-forwarder-transport.Plo
+	-rm -f tools/micro-forwarder/$(DEPDIR)/micro-forwarder.Plo
 	-rm -f tools/usersync/$(DEPDIR)/channel-discovery.Plo
 	-rm -f tools/usersync/$(DEPDIR)/content-meta-info.Plo
 	-rm -f tools/usersync/$(DEPDIR)/content-meta-info.pb.Plo
@@ -6960,6 +6989,8 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator-validator-fixture.Po
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-identity-management-fixture.Po
 	-rm -f tests/unit-tests/$(DEPDIR)/bin_unit_tests_test_validator_null-test-validator-null.Po
+	-rm -f tools/micro-forwarder/$(DEPDIR)/micro-forwarder-transport.Plo
+	-rm -f tools/micro-forwarder/$(DEPDIR)/micro-forwarder.Plo
 	-rm -f tools/usersync/$(DEPDIR)/channel-discovery.Plo
 	-rm -f tools/usersync/$(DEPDIR)/content-meta-info.Plo
 	-rm -f tools/usersync/$(DEPDIR)/content-meta-info.pb.Plo

--- a/Makefile.in
+++ b/Makefile.in
@@ -327,6 +327,7 @@ am_libndn_ind_la_OBJECTS = $(am__objects_2) $(am__objects_1) \
 	src/lite/registration-options-lite.lo \
 	src/lite/signature-lite.lo \
 	src/lite/encoding/element-listener-lite.lo \
+	src/lite/encoding/element-reader-lite.lo \
 	src/lite/encoding/tlv-0_2-wire-format-lite.lo \
 	src/lite/encoding/tlv-0_3-wire-format-lite.lo \
 	src/lite/encrypt/encrypted-content-lite.lo \
@@ -899,6 +900,7 @@ am__depfiles_remade = contrib/apache/$(DEPDIR)/apr_base64.Plo \
 	src/lite/$(DEPDIR)/registration-options-lite.Plo \
 	src/lite/$(DEPDIR)/signature-lite.Plo \
 	src/lite/encoding/$(DEPDIR)/element-listener-lite.Plo \
+	src/lite/encoding/$(DEPDIR)/element-reader-lite.Plo \
 	src/lite/encoding/$(DEPDIR)/tlv-0_2-wire-format-lite.Plo \
 	src/lite/encoding/$(DEPDIR)/tlv-0_3-wire-format-lite.Plo \
 	src/lite/encrypt/$(DEPDIR)/encrypted-content-lite.Plo \
@@ -1785,6 +1787,7 @@ ndn_ind_cpp_headers = \
   include/ndn-ind/lite/registration-options-lite.hpp \
   include/ndn-ind/lite/signature-lite.hpp \
   include/ndn-ind/lite/encoding/element-listener-lite.hpp \
+  include/ndn-ind/lite/encoding/element-reader-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_1_1-wire-format-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_2-wire-format-lite.hpp \
   include/ndn-ind/lite/encoding/tlv-0_3-wire-format-lite.hpp \
@@ -2017,6 +2020,7 @@ libndn_ind_la_SOURCES = ${libndn_c_la_SOURCES} ${ndn_ind_cpp_headers} \
   src/lite/registration-options-lite.cpp \
   src/lite/signature-lite.cpp \
   src/lite/encoding/element-listener-lite.cpp \
+  src/lite/encoding/element-reader-lite.cpp \
   src/lite/encoding/tlv-0_2-wire-format-lite.cpp \
   src/lite/encoding/tlv-0_3-wire-format-lite.cpp \
   src/lite/encrypt/encrypted-content-lite.cpp \
@@ -2767,6 +2771,9 @@ src/lite/encoding/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/lite/encoding/$(DEPDIR)
 	@: > src/lite/encoding/$(DEPDIR)/$(am__dirstamp)
 src/lite/encoding/element-listener-lite.lo:  \
+	src/lite/encoding/$(am__dirstamp) \
+	src/lite/encoding/$(DEPDIR)/$(am__dirstamp)
+src/lite/encoding/element-reader-lite.lo:  \
 	src/lite/encoding/$(am__dirstamp) \
 	src/lite/encoding/$(DEPDIR)/$(am__dirstamp)
 src/lite/encoding/tlv-0_2-wire-format-lite.lo:  \
@@ -3985,6 +3992,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/$(DEPDIR)/registration-options-lite.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/$(DEPDIR)/signature-lite.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/encoding/$(DEPDIR)/element-listener-lite.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/lite/encoding/$(DEPDIR)/element-reader-lite.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/encoding/$(DEPDIR)/tlv-0_2-wire-format-lite.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/encoding/$(DEPDIR)/tlv-0_3-wire-format-lite.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/lite/encrypt/$(DEPDIR)/encrypted-content-lite.Plo@am__quote@ # am--include-marker
@@ -6409,6 +6417,7 @@ distclean: distclean-recursive
 	-rm -f src/lite/$(DEPDIR)/registration-options-lite.Plo
 	-rm -f src/lite/$(DEPDIR)/signature-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/element-listener-lite.Plo
+	-rm -f src/lite/encoding/$(DEPDIR)/element-reader-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/tlv-0_2-wire-format-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/tlv-0_3-wire-format-lite.Plo
 	-rm -f src/lite/encrypt/$(DEPDIR)/encrypted-content-lite.Plo
@@ -6787,6 +6796,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f src/lite/$(DEPDIR)/registration-options-lite.Plo
 	-rm -f src/lite/$(DEPDIR)/signature-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/element-listener-lite.Plo
+	-rm -f src/lite/encoding/$(DEPDIR)/element-reader-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/tlv-0_2-wire-format-lite.Plo
 	-rm -f src/lite/encoding/$(DEPDIR)/tlv-0_3-wire-format-lite.Plo
 	-rm -f src/lite/encrypt/$(DEPDIR)/encrypted-content-lite.Plo

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj
@@ -329,6 +329,7 @@
     <ClCompile Include="..\..\src\lite\data-lite.cpp" />
     <ClCompile Include="..\..\src\lite\delegation-set-lite.cpp" />
     <ClCompile Include="..\..\src\lite\encoding\element-listener-lite.cpp" />
+    <ClCompile Include="..\..\src\lite\encoding\element-reader-lite.cpp" />
     <ClCompile Include="..\..\src\lite\encoding\tlv-0_2-wire-format-lite.cpp" />
     <ClCompile Include="..\..\src\lite\encoding\tlv-0_3-wire-format-lite.cpp" />
     <ClCompile Include="..\..\src\lite\encrypt\algo\aes-algorithm-lite.cpp" />
@@ -456,6 +457,8 @@
     <ClCompile Include="..\..\src\util\regex\ndn-regex-top-matcher.cpp" />
     <ClCompile Include="..\..\src\util\segment-fetcher.cpp" />
     <ClCompile Include="..\..\src\util\sqlite3-statement.cpp" />
+    <ClCompile Include="..\..\tools\micro-forwarder\micro-forwarder-transport.cpp" />
+    <ClCompile Include="..\..\tools\micro-forwarder\micro-forwarder.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
@@ -130,6 +130,12 @@
     <Filter Include="Source Files\src\util\regex">
       <UniqueIdentifier>{c1e558a0-a60f-4ad8-9e5e-255520134fd3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\tools">
+      <UniqueIdentifier>{3c69295c-b92e-463a-9181-bf771e7e3e13}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\tools\micro-forwarder">
+      <UniqueIdentifier>{ac6865cd-602c-4efb-8680-7d69681d3bb4}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -1027,6 +1033,15 @@
     </ClCompile>
     <ClCompile Include="..\..\src\lite\signature-lite.cpp">
       <Filter>Source Files\src\lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tools\micro-forwarder\micro-forwarder.cpp">
+      <Filter>Source Files\tools\micro-forwarder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tools\micro-forwarder\micro-forwarder-transport.cpp">
+      <Filter>Source Files\tools\micro-forwarder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lite\encoding\element-reader-lite.cpp">
+      <Filter>Source Files\src\lite\encoding</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,7 +38,6 @@ ndn_cpp_cpp_headers = \
   $(wildcard ndn-ind/security/v2/*.*) \
   $(wildcard ndn-ind/security/v2/validator-config/*.*) \
   $(wildcard ndn-ind/sync/*.*) \
-  $(wildcard ndn-ind/tools/usersync/*.*) \
   $(wildcard ndn-ind/transport/*.*) \
   $(wildcard ndn-ind/util/*.*) \
   $(wildcard ndn-ind/util/impl/*.*)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -44,6 +44,7 @@ ndn_cpp_cpp_headers = \
 
 # Public ndn-ind-tools C++ headers.
 ndn_cpp_tools_cpp_headers = \
+  $(wildcard ndn-ind-tools/micro-forwarder/*.*) \
   $(wildcard ndn-ind-tools/usersync/*.*)
 
 nobase_include_HEADERS = $(ndn_cpp_c_headers) $(ndn_cpp_cpp_headers) \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -397,7 +397,6 @@ ndn_cpp_cpp_headers = \
   $(wildcard ndn-ind/security/v2/*.*) \
   $(wildcard ndn-ind/security/v2/validator-config/*.*) \
   $(wildcard ndn-ind/sync/*.*) \
-  $(wildcard ndn-ind/tools/usersync/*.*) \
   $(wildcard ndn-ind/transport/*.*) \
   $(wildcard ndn-ind/util/*.*) \
   $(wildcard ndn-ind/util/impl/*.*)

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -404,6 +404,7 @@ ndn_cpp_cpp_headers = \
 
 # Public ndn-ind-tools C++ headers.
 ndn_cpp_tools_cpp_headers = \
+  $(wildcard ndn-ind-tools/micro-forwarder/*.*) \
   $(wildcard ndn-ind-tools/usersync/*.*)
 
 nobase_include_HEADERS = $(ndn_cpp_c_headers) $(ndn_cpp_cpp_headers) \

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
@@ -1,0 +1,205 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: From ndn-squirrel https://github.com/remap/ndn-squirrel/blob/master/src/transport/micro-forwarder-transport.nut
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#ifndef NDN_MICRO_FORWARDER_TRANSPORT_HPP
+#define NDN_MICRO_FORWARDER_TRANSPORT_HPP
+
+#include "micro-forwarder.hpp"
+#include <ndn-ind/lite/util/dynamic-malloc-uint8-array-lite.hpp>
+#include <ndn-ind/lite/encoding/element-reader-lite.hpp>
+#include <ndn-ind/transport/transport.hpp>
+
+namespace ndntools {
+
+/**
+ * A MicroForwarderTransport extends Transport to communicate with a
+ * MicroForwarder object. This can be used as the transport in the Face constructor.
+ */
+class ndn_ind_dll MicroForwarderTransport : public ndn::Transport {
+public:
+  /**
+   * A MicroForwarderTransport::ConnectionInfo extends Transport::ConnectionInfo
+   * to hold the MicroForwarder object to connect to.
+   */
+  class ConnectionInfo : public Transport::ConnectionInfo {
+  public:
+    /**
+     * Create a ConnectionInfo for the forwarder object.
+     * @param forwarder (optional) The MicroForwarder to communicate with. If
+     * omitted or null, use the default MicroForwarder::get().
+     */
+    ConnectionInfo(MicroForwarder* forwarder = 0)
+    {
+      forwarder_ = (forwarder ? forwarder : MicroForwarder::get());
+    }
+
+    /**
+     * Get the MicroForwarder object given to the constructor.
+     * @return The MicroForwarder object.
+     */
+    MicroForwarder*
+    getForwarder() const { return forwarder_; }
+
+    virtual
+    ~ConnectionInfo();
+
+  private:
+    MicroForwarder* forwarder_;
+  };
+
+  /**
+   * Create a MicroForwarderTransport.
+   */
+  MicroForwarderTransport();
+
+  /**
+   * Determine whether this transport connecting according to connectionInfo is
+   * to a node on the current machine. MicroForwarder transports are always local.
+   * @param connectionInfo This is ignored.
+   * @return True because MicroForwarder transports are always local.
+   */
+  virtual bool
+  isLocal(const ndn::Transport::ConnectionInfo& connectionInfo);
+
+  /**
+   * Override to return false since connect does not need to use the onConnected
+   * callback.
+   * @return False.
+   */
+  virtual bool
+  isAsync();
+
+  /**
+   * Connect to connectionInfo.getForwarder() by calling its addFace with an
+   * endpoint Transport connected to this Transport. processEvents() will use
+   * elementListener.
+   * @param connectionInfo The ConnectionInfo with the MicroForwarder object.
+   * @param elementListener Not a shared_ptr because we assume that it will
+   * remain valid during the life of this object.
+   * @param onConnected This calls onConnected() when the connection is
+   * established.
+   */
+  virtual void
+  connect
+    (const ndn::Transport::ConnectionInfo& connectionInfo,
+     ndn::ElementListener& elementListener, const OnConnected& onConnected);
+
+  /**
+   * Send data to the MicroForwarder indicated by the ConnectionInfo.
+   * @param data A pointer to the buffer of data to send.
+   * @param dataLength The number of bytes in data.
+   */
+  virtual void
+  send(const uint8_t *data, size_t dataLength);
+
+  /**
+   * This is called by Face.processEvents(). Just call the MicroForwarder's
+   * processEvents() (which will call processEvents() for its Transport objects).
+   */
+  virtual void
+  processEvents();
+
+  virtual bool
+  getIsConnected();
+
+private:
+  /**
+   * A MicroForwarderTransport::Endpoint extends Transport and is the the
+   * Transport used in calling the MicroForwarder addFace method, as the endpoint
+   * of this connection in the MicroForwarder.
+   */
+  class Endpoint : public ndn::Transport {
+  public:
+    Endpoint(MicroForwarderTransport* transport)
+    : elementBuffer_(1000),
+      elementReader_(0, &elementBuffer_),
+      transport_(transport)
+    {}
+
+    virtual bool
+    isLocal(const ndn::Transport::ConnectionInfo& connectionInfo) { return true;}
+
+    virtual bool
+    isAsync() { return false; }
+
+    /**
+     * This is called by the MicroForwarder when MicroForwarderTransport::connect
+     * calls the MicroForwarder's addFace. Give the elementListener to the
+     * elementReader_.
+     * @param connectionInfo
+     * @param elementListener
+     * @param onConnected
+     */
+    virtual void
+    connect(const ndn::Transport::ConnectionInfo& connectionInfo,
+      ndn::ElementListener& elementListener, const OnConnected& onConnected)
+    {
+      // Ignore the connectionInfo. We already got what we need in the constructor.
+      elementReader_.reset(&ndn::ElementListenerLite::downCast(elementListener));
+
+      if (onConnected)
+        onConnected();
+    }
+
+    /**
+     * This is called by MicroForwarderTransport::send. Just pass the data to
+     * the elementReader_ which will call onReceivedElement on the
+     * elementListener provided by the MicroForwarder (when
+     * MicroForwarderTransport::connect called its addFace).
+     */
+    void
+    onReceivedData(const uint8_t *data, size_t dataLength)
+    {
+      elementReader_.onReceivedData(data, dataLength);
+    }
+
+    /**
+     * Pass the data to the MicroForwarderTransport which will call
+     * onReceivedElement on the elementListener given to its connect method.
+     */
+    virtual void
+    send(const uint8_t *data, size_t dataLength)
+    {
+      transport_->elementReader_.onReceivedData(data, dataLength);
+    }
+
+    virtual void
+    processEvents() {}
+
+    virtual bool
+    getIsConnected() { return true; }
+
+  private:
+    ndn::DynamicMallocUInt8ArrayLite elementBuffer_;
+    ndn::ElementReaderLite elementReader_;
+    MicroForwarderTransport* transport_;
+  };
+
+private:
+  ConnectionInfo connectionInfo_;
+  ndn::DynamicMallocUInt8ArrayLite elementBuffer_;
+  ndn::ElementReaderLite elementReader_;
+  ndn::ptr_lib::shared_ptr<Endpoint> endpoint_;
+};
+
+}
+
+#endif

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -1,0 +1,400 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: From ndn-squirrel https://github.com/remap/ndn-squirrel/blob/master/tools/micro-forwarder.nut
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#ifndef NDN_MICRO_FORWARDER_HPP
+#define NDN_MICRO_FORWARDER_HPP
+
+#include <ndn-ind/interest.hpp>
+#include <ndn-ind/data.hpp>
+#include <ndn-ind/transport/transport.hpp>
+
+namespace ndntools {
+
+/**
+ * A MicroForwarder holds a PIT, FIB and faces to function as a simple NDN
+ * forwarder. It has a single instance which you can access with
+ * MicroForwarder::get().
+ */
+class ndn_ind_dll MicroForwarder {
+  class ForwarderFace;
+
+public:
+  MicroForwarder()
+  : minPitEntryLifetime_(std::chrono::minutes(1)),
+    localhostNamePrefix("/localhost"),
+    localhopNamePrefix("/localhop"),
+    broadcastNamePrefix("/ndn/broadcast")
+  {
+  }
+
+  /**
+   * Add a new face to communicate with the given transport. This immediately
+   * connects using the connectionInfo.
+   * @param uri The URI to use in the faces/query and faces/list commands.
+   * @param transport An object of a subclass of Transport to use
+   * for communication. If the transport object has a "setOnReceivedObject"
+   * method, then use it to set the onReceivedObject callback.
+   * @param connectionInfo This must be a ConnectionInfo from the same subclass
+   * of Transport as transport.
+   * @return The new face ID.
+   */
+  int
+  addFace
+    (const std::string& uri, 
+     const ndn::ptr_lib::shared_ptr<ndn::Transport>& transport,
+     const ndn::ptr_lib::shared_ptr<const ndn::Transport::ConnectionInfo>& connectionInfo);
+
+  /**
+   * Add a new face to communicate with TCP to host:port. This immediately
+   * connects. The URI to use in the faces/query and faces/list commands will be
+   * "tcp://host:port" .
+   * @param host The host for the TCP connection.
+   * @param port (optional) The port for the TCP connection. If omitted, use 6363.
+   * @return The new face ID.
+   */
+  int
+  addFace(const char *host, unsigned short port = 6363);
+
+  /**
+   * Find or create the FIB entry with the given name and add the ForwarderFace
+   * with the given faceId. All routes are multicast by default.
+   * @param name The name of the FIB entry.
+   * @param faceId The face ID of the face for the route.
+   * @param cost (optional) The cost of the next hop for the given face. If a
+   * next hop for the given name and face already exists, update its cost with
+   * this value. If omitted, use 0.
+   * @return True for success, or false if can't find the ForwarderFace with
+   * faceId.
+   */
+  bool
+  registerRoute(const ndn::Name& name, int faceId, int cost = 0);
+
+  /**
+   * Call processEvents() for the Transport object in each face. This is
+   * normally called by MicroForwarderTransport::processEvents() which is called
+   * by the application when it calls Face::processEvents(), so an application
+   * normally doesn't need to call this directly.
+   */
+  void
+  processEvents();
+
+  /**
+   * This is called by the Transport's ElementListener when an entire TLV
+   * element is received. If it is an Interest, look in the FIB for forwarding.
+   * If it is a Data packet, look in the PIT to match an Interest.
+   * @param face The ForwarderFace with the Transport that received the element.
+   * @param element A pointer to the element. The element buffer is
+   * only valid during the call to onReceivedElement. If you need the data in
+   * the buffer after onReceivedElement returns, then you must copy it.
+   * @param elementLength The length of element
+   */
+  void
+  onReceivedElement
+    (ForwarderFace* face, const uint8_t *element, size_t elementLength);
+
+  /**
+   * Get a singleton instance of a MicroForwarder.
+   * @return The singleton instance.
+   */
+  static MicroForwarder*
+  get()
+  {
+    if (!instance_)
+      instance_ = new MicroForwarder();
+
+    return instance_;
+  }
+
+private:
+  /**
+   * A ForwarderFace is used by the faces list to represent a connection using
+   * the* given Transport. (This is not to be confused with the application Face.)
+   */
+  class ForwarderFace : public ndn::ElementListener {
+  public:
+    /**
+     * Create a ForwarderFace and set the faceId to a unique value.
+     * @param parent The parent MicroForwarder.
+     * @param uri The URI to use in the faces/query and faces/list commands.
+     * @param transport Communicate using the Transport object. You must call
+     * transport.connect with an elementListener object whose
+     * onReceivedElement(element, elementLength) calls
+     * MicroForwarder.onReceivedElement(face, element, elementLength), with this
+     * face.
+     */
+    ForwarderFace
+      (MicroForwarder* parent, const std::string uri,
+       const ndn::ptr_lib::shared_ptr<ndn::Transport>& transport)
+    : parent_(parent), uri_(uri), transport_(transport)
+    {
+      faceId_ = ++lastFaceId_;
+    }
+
+    const std::string&
+    getUri() const { return uri_; }
+
+    int
+    getFaceId() const { return faceId_; }
+
+    /**
+     * Check if this face is still enabled.
+     * @returns True if this face is still enabled.
+     */
+    bool
+    isEnabled() { return !!transport_; }
+
+    /**
+     * Disable this face so that isEnabled() returns false.
+     */
+    void
+    disable() { transport_.reset(); };
+
+    /**
+     * Send the data buffer to the transport
+     * @param data A pointer to the buffer of data to send.
+     * @param dataLength The number of bytes in data.
+     */
+    void
+    send(const uint8_t *data, size_t dataLength)
+    {
+      if (transport_)
+        transport_->send(data, dataLength);
+    }
+
+    void
+    send(const std::vector<uint8_t>& data) { send(&data[0], data.size()); }
+
+    /**
+     * Call transport_->processEvents().
+     */
+    void
+    processEvents() { transport_->processEvents(); }
+
+    /**
+     * This overrides ElementListener::onReceivedElement and is called by the
+     * Transport when a new TLV element is received. Just call the parent
+     * onReceivedElement.
+     */
+    void
+    onReceivedElement(const uint8_t *element, size_t elementLength) override;
+
+  private:
+    MicroForwarder* parent_;
+    std::string uri_;
+    ndn::ptr_lib::shared_ptr<ndn::Transport> transport_;
+    int faceId_;
+    static int lastFaceId_;
+  };
+
+  /**
+   * A PitEntry is used in the PIT to record the face on which an Interest came
+   * in. (This is not to be confused with the PIT entry object used by the
+   * application library's PendingInterestTable class.)
+   */
+  class PitEntry {
+  public:
+    /**
+     * Create a PitEntry for the interest and incoming face.
+     * @param interest The pending Interest. This does not make a copy.
+     * @param inFace The Interest's incoming face (and where the matching Data
+     * packet will be sent).
+     * @param timeoutEndTime The time when the interest times out.
+     * @param entryEndTime The time when this entry should be removed.
+     */
+    PitEntry
+      (const ndn::ptr_lib::shared_ptr<ndn::Interest>& interest,
+       ForwarderFace* inFace,
+       std::chrono::system_clock::time_point timeoutEndTime,
+       std::chrono::system_clock::time_point entryEndTime)
+    : interest_(interest), inFace_(inFace),
+      timeoutEndTime_(timeoutEndTime), entryEndTime_(entryEndTime),
+      isRemoved_(false)
+    {
+    }
+
+    ndn::ptr_lib::shared_ptr<ndn::Interest>&
+    getInterest() { return interest_; }
+
+    ForwarderFace*
+    getInFace() { return inFace_; }
+
+    void
+    clearInFace() { inFace_ = 0; }
+
+    std::chrono::system_clock::time_point
+    getTimeoutEndTime() { return timeoutEndTime_; }
+
+    void
+    setTimeoutEndTime(std::chrono::system_clock::time_point timeoutEndTime)
+    {
+      timeoutEndTime_ = timeoutEndTime;
+    }
+
+    std::chrono::system_clock::time_point
+    getEntryEndTime() { return entryEndTime_; }
+
+    void
+    setEntryEndTime(std::chrono::system_clock::time_point entryEndTime)
+    {
+      entryEndTime_ = entryEndTime;
+    }
+
+    /**
+     * Set the isRemoved_ flag true.
+     */
+    void
+    setIsRemoved() { isRemoved_ = true; }
+
+  private:
+    ndn::ptr_lib::shared_ptr<ndn::Interest> interest_;
+    ForwarderFace* inFace_;
+    // timeoutEndTime_ is based on the Interest lifetime.
+    std::chrono::system_clock::time_point timeoutEndTime_;
+    // entryEndTime_ is when this entry should be removed. (The entry is kept
+    // around longer than the Interest lifetime to detect a duplicate nonce.)
+    std::chrono::system_clock::time_point entryEndTime_;
+    bool isRemoved_;
+  };
+
+  /**
+   * A FibEntry holds a list of NextHopRecord where each record has a
+   * ForwarderFace and its related cost.
+   */
+  class NextHopRecord {
+  public:
+    /**
+     * Create a NextHopRecord with the given values.
+     * @param face The ForwarderFace for this next hop.
+     * @param cost The cost of this next hop on the given face.
+     */
+    NextHopRecord(ForwarderFace* face, int cost)
+    : face_(face), cost_(cost)
+    {
+    }
+
+    ForwarderFace*
+    getFace() { return face_; }
+
+    int
+    getCost() { return cost_; }
+
+    void
+    setCost(int cost) { cost_ = cost; }
+
+  private:
+    ForwarderFace* face_;
+    int cost_;
+  };
+
+  /**
+   * A FibEntry is used in the FIB to match a registered name with a list of
+   * related NextHopRecord.
+   */
+  class FibEntry {
+  public:
+    /**
+     * Create a FibEntry with the given registered name.
+     * @param name The registered name for this FIB entry.
+     */
+    FibEntry (const ndn::Name& name)
+    : name_(name)
+    {
+    }
+
+    ndn::Name&
+    getName() { return name_; }
+
+    /**
+     * Get the number of entries in the list of NextHopRecord.
+     * @return The number of entries.
+     */
+    int
+    getNextHopCount() { return nextHops_.size(); }
+
+    /**
+     * Get the NextHopRecord at the given index.
+     * @param i The index in the list of NextHopRecord.
+     * @return The NextHopRecord.
+     */
+    NextHopRecord&
+    getNextHop(int i) { return *nextHops_[i]; }
+
+    void
+    addNextHop(const ndn::ptr_lib::shared_ptr<NextHopRecord>& nextHop)
+    {
+      nextHops_.push_back(nextHop);
+    }
+
+    /**
+     * Get the index in the list of NextHopRecord with the given face.
+     * @param fact The face to search for.
+     * @return The index of the matching NextHopRecord, or -1 if not found.
+     */
+    int
+    nextHopIndexOf(ForwarderFace* face)
+    {
+      for (int i = 0; i < nextHops_.size(); ++i) {
+        if (nextHops_[i]->getFace() == face)
+          return i;
+      }
+
+      return -1;
+    }
+
+  private:
+    ndn::Name name_;
+    std::vector<ndn::ptr_lib::shared_ptr<NextHopRecord> > nextHops_;
+  };
+
+  /**
+   * Find the face in faces_ with the faceId.
+   * @param The faceId.
+   * @return The ForwarderFace, or null if not found.
+   */
+  ForwarderFace*
+  findFace(int faceId);
+
+  /**
+   * Mark the PitEntry at PIT_[i] as removed (in case something references it)
+   * and remove it.
+   */
+  void
+  removePitEntry(int i)
+  {
+    PIT_[i]->setIsRemoved();
+    PIT_.erase(PIT_.begin() + i);
+  }
+
+  std::vector<ndn::ptr_lib::shared_ptr<PitEntry> > PIT_;
+  std::vector<ndn::ptr_lib::shared_ptr<FibEntry> > FIB_;
+  std::vector<ndn::ptr_lib::shared_ptr<ForwarderFace> > faces_;
+  std::chrono::nanoseconds minPitEntryLifetime_;
+
+  ndn::Name localhostNamePrefix;
+  ndn::Name localhopNamePrefix;
+  ndn::Name broadcastNamePrefix;
+
+  static MicroForwarder* instance_;
+};
+
+}
+
+#endif

--- a/include/ndn-ind/lite/encoding/element-listener-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-listener-lite.hpp
@@ -61,11 +61,30 @@ public:
    */
   ElementListenerLite(OnReceivedElementLite onReceivedElement);
 
+  /**
+   * Downcast the reference to the ndn_ElementListener struct to an
+   * ElementListenerLite.
+   * @param encryptedContent A reference to the ndn_ElementListener struct.
+   * @return The same reference as ElementListenerLite.
+   */
+  static ElementListenerLite&
+  downCast(ndn_ElementListener& encryptedContent)
+  {
+    return *(ElementListenerLite*)&encryptedContent;
+  }
+
+  static const ElementListenerLite&
+  downCast(const ndn_ElementListener& encryptedContent)
+  {
+    return *(ElementListenerLite*)&encryptedContent;
+  }
+
 private:
   // Declare friends who can downcast to the private base.
   friend class TcpTransportLite;
   friend class UdpTransportLite;
   friend class UnixTransportLite;
+  friend class ElementReaderLite;
 };
 
 }

--- a/include/ndn-ind/lite/encoding/element-listener-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-listener-lite.hpp
@@ -1,7 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
  * Copyright (C) 2020 Operant Networks, Incorporated.
- * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This works is based substantially on previous work as listed below:
  *

--- a/include/ndn-ind/lite/encoding/element-reader-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-reader-lite.hpp
@@ -1,7 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /**
  * Copyright (C) 2021 Operant Networks, Incorporated.
- * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/include/ndn-ind/lite/encoding/element-reader-lite.hpp
+++ b/include/ndn-ind/lite/encoding/element-reader-lite.hpp
@@ -1,0 +1,81 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#ifndef NDN_ELEMENT_READER_LITE_HPP
+#define NDN_ELEMENT_READER_LITE_HPP
+
+#include "../util/dynamic-uint8-array-lite.hpp"
+#include "element-listener-lite.hpp"
+
+namespace ndn {
+
+/**
+ * An ElementReaderLite lets the application call onReceivedData() which calls
+ * elementListener->onReceivedElement when an entire element has been read.
+ *
+ */
+class ndn_ind_dll ElementReaderLite : private ndn_ElementReader {
+public:
+  /**
+   * Create an ElementReaderLite with the elementListener and a buffer for saving
+   * partial data.
+   * @param elementListener A pointer to the ElementListenerLite used by
+   * onReceivedData. If this is null, you can set it later with reset().
+   * @param buffer A pointer to a DynamicUInt8ArrayLite which is used to save data
+   * before calling the elementListener. The object must remain valid during the
+   * entire life of this ElementReaderLite. If the reallocFunction function
+   * pointer is null, its array must be large enough to save a full element,
+   * perhaps MAX_NDN_PACKET_SIZE bytes.
+   * However, if readRawPackets is true, then the buffer is not used.
+   * @param readRawPackets (optional) If true, then call
+   * elementListener->onReceivedElement for each received packet as-is. If omitted
+   * or false,then use the ndn_TlvStructureDecoder to ensure that
+   * elementListener->onReceivedElement is called once for a whole TLV packet.
+   */
+  ElementReaderLite
+    (ElementListenerLite* elementListener, DynamicUInt8ArrayLite* buffer,
+     bool readRawPackets = false);
+
+  /**
+   * Reset the state of this ElementReaderLite to begin reading new data and use
+   * the given elementListener. Keep using the buffer provided to the constructor.
+   * @param elementListener A pointer to the ElementListenerLite used by
+   * onReceivedData.
+   */
+  void
+  reset(ElementListenerLite* elementListener);
+
+  /**
+   * Continue to read data until the end of an element, then call
+   * (*elementListener->onReceivedElement)(element, elementLength).
+   * The buffer passed to onReceivedElement is only valid during this call. If
+   * you need the data later, you must copy.
+   * @param data pointer to the buffer with the incoming element's bytes.
+   * @param dataLength length of data.
+   * @return 0 for success, else an error code.
+   */
+  ndn_Error
+  onReceivedData(const uint8_t *data, size_t dataLength);
+};
+
+}
+
+#endif

--- a/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
+++ b/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
@@ -1,7 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil -*- */
 /**
  * Copyright (C) 2020 Operant Networks, Incorporated.
- * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This works is based substantially on previous work as listed below:
  *

--- a/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
+++ b/include/ndn-ind/lite/util/dynamic-uint8-array-lite.hpp
@@ -164,6 +164,7 @@ private:
   friend class UnixTransportLite;
   friend class Tlv0_2WireFormatLite;
   friend class Tlv0_3WireFormatLite;
+  friend class ElementReaderLite;
 };
 
 }

--- a/src/lite/encoding/element-reader-lite.cpp
+++ b/src/lite/encoding/element-reader-lite.cpp
@@ -1,7 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /**
  * Copyright (C) 2021 Operant Networks, Incorporated.
- * @author: Jeff Thompson <jefft0@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/lite/encoding/element-reader-lite.cpp
+++ b/src/lite/encoding/element-reader-lite.cpp
@@ -1,0 +1,47 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: Jeff Thompson <jefft0@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#include "../../c/encoding/element-reader.h"
+#include <ndn-ind/lite/encoding/element-reader-lite.hpp>
+
+namespace ndn {
+
+ElementReaderLite::ElementReaderLite
+  (ElementListenerLite* elementListener, DynamicUInt8ArrayLite* buffer,
+   bool readRawPackets)
+{
+  ndn_ElementReader_initialize
+    (this, elementListener, buffer, readRawPackets ? 1 : 0);
+}
+
+void
+ElementReaderLite::reset(ElementListenerLite* elementListener)
+{
+  ndn_ElementReader_reset(this, elementListener);
+}
+
+ndn_Error
+ElementReaderLite::onReceivedData(const uint8_t *data, size_t dataLength)
+{
+  return ndn_ElementReader_onReceivedData(this, data, dataLength);
+}
+
+}

--- a/tools/micro-forwarder/micro-forwarder-transport.cpp
+++ b/tools/micro-forwarder/micro-forwarder-transport.cpp
@@ -1,0 +1,108 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: From ndn-squirrel https://github.com/remap/ndn-squirrel/blob/master/src/transport/micro-forwarder-transport.nut
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#include <ndn-ind/util/logging.hpp>
+#include <ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp>
+
+using namespace std;
+using namespace std::chrono;
+using namespace ndn;
+using namespace ndn::func_lib;
+
+INIT_LOGGER("ndntools.MicroForwarderTransport");
+
+namespace ndntools {
+
+MicroForwarderTransport::ConnectionInfo::~ConnectionInfo()
+{
+}
+
+MicroForwarderTransport::MicroForwarderTransport()
+: elementBuffer_(1000),
+  elementReader_(0, &elementBuffer_)
+{
+}
+
+bool
+MicroForwarderTransport::isLocal(const Transport::ConnectionInfo& connectionInfo)
+{
+  return true;
+}
+
+bool
+MicroForwarderTransport::isAsync() { return false; }
+
+void
+MicroForwarderTransport::connect
+  (const Transport::ConnectionInfo& connectionInfo,
+   ElementListener& elementListener, const OnConnected& onConnected)
+{
+  const MicroForwarderTransport::ConnectionInfo* microforwarderConnectionInfo =
+    dynamic_cast<const MicroForwarderTransport::ConnectionInfo*>(&connectionInfo);
+  if (!microforwarderConnectionInfo)
+    throw runtime_error
+      ("MicroForwarderTransport::connect: connectionInfo is not a MicroForwarderTransport::ConnectionInfo");
+  if (!microforwarderConnectionInfo->getForwarder())
+    throw runtime_error
+      ("MicroForwarderTransport::connect: connectionInfo getForwarder() is null");
+
+  connectionInfo_ = *microforwarderConnectionInfo;
+  elementReader_.reset(&ElementListenerLite::downCast(elementListener));
+
+  endpoint_.reset(new Endpoint(this));
+  // Endpoint doesn't use the ConnectionInfo so pass a default object.
+  // The MicroForwader will call endpoint_->connect with its elementListener.
+  int faceId = connectionInfo_.getForwarder()->addFace
+    ("internal://app", endpoint_, ptr_lib::make_shared<Transport::ConnectionInfo>());
+  connectionInfo_.getForwarder()->registerRoute(Name("/"), faceId);
+
+  if (onConnected)
+    onConnected();
+}
+
+void
+MicroForwarderTransport::send(const uint8_t *data, size_t dataLength)
+{
+  if (!endpoint_)
+    // This should have been set in connect().
+    throw std::runtime_error
+      ("MicroForwarderTransport.send: The transport is not connected");
+
+  // This will call onReceivedElement on the ElementListener provided by the
+  // MicroForwader.
+  endpoint_->onReceivedData(data, dataLength);
+}
+
+void
+MicroForwarderTransport::processEvents()
+{
+  if (connectionInfo_.getForwarder())
+    connectionInfo_.getForwarder()->processEvents();
+}
+
+bool
+MicroForwarderTransport::getIsConnected()
+{
+  // This is created in connect();
+  return !!endpoint_;
+}
+
+}

--- a/tools/micro-forwarder/micro-forwarder.cpp
+++ b/tools/micro-forwarder/micro-forwarder.cpp
@@ -1,0 +1,344 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/**
+ * Copyright (C) 2021 Operant Networks, Incorporated.
+ * @author: From ndn-squirrel https://github.com/remap/ndn-squirrel/blob/master/tools/micro-forwarder.nut
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version, with the additional exemption that
+ * compiling, linking, and/or using OpenSSL is allowed.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+
+#include <ndn-ind/util/logging.hpp>
+#include <ndn-ind/encoding/tlv-wire-format.hpp>
+#include <ndn-ind/lite/encoding/tlv-0_3-wire-format-lite.hpp>
+#include <ndn-ind/lite/lp/lp-packet-lite.hpp>
+#include <ndn-ind/transport/tcp-transport.hpp>
+#include <ndn-ind/network-nack.hpp>
+#include "../../src/lp/lp-packet.hpp"
+#include <ndn-ind-tools/micro-forwarder/micro-forwarder.hpp>
+
+using namespace std;
+using namespace std::chrono;
+using namespace ndn;
+using namespace ndn::func_lib;
+
+INIT_LOGGER("ndntools.MicroForwarder");
+
+namespace ndntools {
+
+int
+MicroForwarder::addFace
+  (const string& uri, const ptr_lib::shared_ptr<Transport>& transport,
+   const ptr_lib::shared_ptr<const Transport::ConnectionInfo>& connectionInfo)
+{
+  auto face = ptr_lib::make_shared<ForwarderFace>(this, uri, transport);
+
+  transport->connect(*connectionInfo, *face, Transport::OnConnected());
+  faces_.push_back(face);
+
+  int faceId = face->getFaceId();
+  _LOG_INFO("Created face " << faceId << ": " << uri);
+  return faceId;
+}
+
+int
+MicroForwarder::addFace(const char *host, unsigned short port)
+{
+  return addFace
+    (string("tcp://") + host + ":" + to_string(port),
+     ptr_lib::make_shared<TcpTransport>(),
+     ptr_lib::make_shared<TcpTransport::ConnectionInfo>(host, port));
+}
+
+bool
+MicroForwarder::registerRoute(const ndn::Name& name, int faceId, int cost)
+{
+  ForwarderFace* nextHopFace = findFace(faceId);
+  if (!nextHopFace) {
+    _LOG_INFO("Register route: Unrecognized face id " << faceId);
+    return false;
+  }
+
+  // Check for a FIB entry for the name and add the face.
+  for (int i = 0; i < FIB_.size(); ++i) {
+    FibEntry& fibEntry = *FIB_[i];
+
+    if (fibEntry.getName().equals(name)) {
+      int nextHopIndex = fibEntry.nextHopIndexOf(nextHopFace);
+      if (nextHopIndex >= 0)
+        // A next hop with the face is already added, so just update its cost.
+        fibEntry.getNextHop(nextHopIndex).setCost(cost);
+      else
+        // The face is not already added.
+        fibEntry.addNextHop(ptr_lib::make_shared<NextHopRecord>(nextHopFace, cost));
+
+      _LOG_INFO("Register route: Added face " << faceId <<
+        " to existing FIB entry for: " << name);
+      return true;
+    }
+  }
+
+  // Make a new FIB entry.
+  auto fibEntry = ptr_lib::make_shared<FibEntry>(name);
+  fibEntry->addNextHop(ptr_lib::make_shared<NextHopRecord>(nextHopFace, cost));
+  FIB_.push_back(fibEntry);
+
+  _LOG_INFO("Register route: Added face id " << faceId <<
+    " to new FIB entry for: " << name);
+  return true;
+}
+
+void
+MicroForwarder::processEvents()
+{
+  for (int i = 0; i < faces_.size(); ++i) {
+    faces_[i]->processEvents();
+  }
+}
+
+void
+MicroForwarder::ForwarderFace::onReceivedElement
+  (const uint8_t *element, size_t elementLength)
+{
+  parent_->onReceivedElement(this, element, elementLength);
+}
+
+void
+MicroForwarder::onReceivedElement
+  (ForwarderFace* face, const uint8_t *element, size_t elementLength)
+{
+  const int Tlv_Interest = 5;
+  const int Tlv_Data = 6;
+  const int Tlv_LpPacket_LpPacket = 100;
+  const uint8_t *interestOrData = element;
+  size_t interestOrDataLength = elementLength;
+  ptr_lib::shared_ptr<LpPacket> lpPacket;
+  if (element[0] == Tlv_LpPacket_LpPacket) {
+    // Decode the LpPacket and replace element with the fragment.
+    // Use LpPacketLite to avoid copying the fragment.
+    struct ndn_LpPacketHeaderField headerFields[5];
+    LpPacketLite lpPacketLite
+      (headerFields, sizeof(headerFields) / sizeof(headerFields[0]));
+
+    ndn_Error error;
+    if ((error = Tlv0_3WireFormatLite::decodeLpPacket
+         (lpPacketLite, element, elementLength)))
+      throw runtime_error(ndn_getErrorString(error));
+    interestOrData = lpPacketLite.getFragmentWireEncoding().buf();
+    interestOrDataLength = lpPacketLite.getFragmentWireEncoding().size();
+    // We have saved the wire encoding, so clear to copy it to lpPacket.
+    lpPacketLite.setFragmentWireEncoding(BlobLite());
+
+    lpPacket.reset(new LpPacket());
+    lpPacket->set(lpPacketLite);
+  }
+
+  // First, decode as Interest or Data.
+  ptr_lib::shared_ptr<Interest> interest;
+  ptr_lib::shared_ptr<Data> data;
+
+  if (interestOrData[0] == Tlv_Interest) {
+    interest.reset(new Interest());
+    interest->wireDecode(interestOrData, interestOrDataLength, *TlvWireFormat::get());
+  }
+  else if (interestOrData[0] == Tlv_Data) {
+    data.reset(new Data());
+    data->wireDecode(interestOrData, interestOrDataLength, *TlvWireFormat::get());
+  }
+
+  auto now = system_clock::now();
+  // Remove timed-out PIT entries
+  // Iterate backwards so we can remove the entry and keep iterating.
+  for (int i = PIT_.size() - 1; i >= 0; --i) {
+    PitEntry& entry = *PIT_[i];
+    // For removal, we also check the timeoutEndTime in case it is greater
+    // than entryEndTime.
+    if (now >= entry.getEntryEndTime() && now >= entry.getTimeoutEndTime())
+      removePitEntry(i);
+    else if (now >= entry.getTimeoutEndTime())
+      // Timed out, so set inFace_ null which prevents using the PIT entry to
+      // return a Data packet, but we keep the PIT entry to check for a
+      // duplicate nonce. (If a fresh Interest arrives with the same name, a
+      // new PIT entry will be created.)
+      entry.clearInFace();
+  }
+
+  if (lpPacket) {
+    ptr_lib::shared_ptr<NetworkNack> networkNack =
+      NetworkNack::getFirstHeader(*lpPacket);
+    if (networkNack) {
+      if (!interest)
+        // We got a Nack but not for an Interest, so drop the packet.
+        return;
+
+      _LOG_DEBUG("Received Interest with Nack on face " << face->getFaceId() <<
+        ": " << interest->getName());
+
+      // Send the packet to the face for each matching PIT entry.
+      // Note that this is similar to returning a Data packet.
+      for (int i = 0; i < PIT_.size(); ++i) {
+        PitEntry& entry = *PIT_[i];
+        // Use exact name match.
+        // TODO: Should we match on prefix? Or should we match the exact nonce?
+        if (entry.getInFace() && entry.getInterest()->getName().equals(interest->getName())) {
+          _LOG_DEBUG("Forwarded Interest with Nack to face " << entry.getInFace()->getFaceId()
+            << ": " << interest->getName());
+          // Forward the full element including any LP header.
+          entry.getInFace()->send(element, elementLength);
+
+          // The PIT entry is consumed, so set clear the inFace_ which prevents
+          // using it to return another Data packet, but we keep the PIT entry to
+          // check for a duplicate nonce. It will be deleted after entryEndTime.
+          // (If a fresh Interest arrives with the same name, a new PIT entry will
+          // be created.)
+          entry.clearInFace();
+        }
+      }
+
+      // We have processed the network Nack packet.
+      return;
+    }
+  }
+
+  // Now process as Interest or Data.
+  if (interest) {
+    _LOG_DEBUG("Received Interest on face " << face->getFaceId() << ": " <<
+       interest->getName());
+
+    if (localhostNamePrefix.match(interest->getName()))
+      // Ignore localhost.
+      return;
+
+    if (localhopNamePrefix.match(interest->getName()))
+      // Ignore localhop.
+      return;
+
+    // First check for a duplicate nonce on any face.
+    for (int i = 0; i < PIT_.size(); ++i) {
+      PitEntry& entry = *PIT_[i];
+      if (entry.getInterest()->getNonce().equals(interest->getNonce())) {
+        _LOG_DEBUG("Dropped Interest with duplicate nonce " << interest->getNonce().toHex()
+          << ": " << interest->getName());
+        return;
+      }
+    }
+
+    // Check for a duplicate Interest.
+    system_clock::time_point timeoutEndTime;
+    if (interest->getInterestLifetime().count() >= 0)
+      timeoutEndTime = now + 
+        duration_cast<system_clock::duration>(interest->getInterestLifetime());
+    else
+      // Use a default timeout.
+      timeoutEndTime = now + seconds(4);
+    system_clock::time_point entryEndTime = 
+      now + duration_cast<system_clock::duration>(minPitEntryLifetime_);
+    for (int i = 0; i < PIT_.size(); ++i) {
+      PitEntry& entry = *PIT_[i];
+      // TODO: Check interest equality of appropriate selectors.
+      if (entry.getInFace() == face &&
+          entry.getInterest()->getName().equals(interest->getName())) {
+        // Duplicate PIT entry.
+        // Update the interest timeout.
+        if (timeoutEndTime > entry.getTimeoutEndTime())
+          entry.setTimeoutEndTime(timeoutEndTime);
+        // Also update the PIT entry timeout.
+        entry.setEntryEndTime(entryEndTime);
+
+        _LOG_DEBUG("Duplicate Interest on face " << face->getFaceId() << ": "
+          << interest->getName());
+        return;
+      }
+    }
+
+    // Add to the PIT.
+    auto pitEntry = ptr_lib::make_shared<PitEntry>
+      (interest, face, timeoutEndTime, entryEndTime);
+    PIT_.push_back(pitEntry);
+    _LOG_DEBUG("Added PIT entry for Interest: " << interest->getName());
+
+    if (broadcastNamePrefix.match(interest->getName())) {
+      // Special case: broadcast to all faces.
+      for (int i = 0; i < faces_.size(); ++i) {
+        ForwarderFace* outFace = faces_[i].get();
+        // Don't send the interest back to where it came from.
+        if (outFace != face) {
+          _LOG_DEBUG("Broadcasted Interest to face " << outFace->getFaceId() << ": "
+            << interest->getName());
+          // Forward the full element including any LP header.
+          outFace->send(element, elementLength);
+        }
+      }
+    }
+    else {
+      // Send the interest to the faces in matching FIB entries.
+      for (int i = 0; i < FIB_.size(); ++i) {
+        FibEntry& fibEntry = *FIB_[i];
+
+        // This behavior is multicast.
+        // TODO: Need to allow for "best route" and longest prefix match?
+        if (fibEntry.getName().match(interest->getName())) {
+          for (int j = 0; j < fibEntry.getNextHopCount(); ++j) {
+            ForwarderFace* outFace = fibEntry.getNextHop(j).getFace();
+
+            // Don't send the interest back to where it came from.
+            if (outFace != face) {
+              _LOG_DEBUG("Forwarded Interest to face " << outFace->getFaceId() << ": "
+                << interest->getName());
+              // Forward the full element including any LP header.
+              outFace->send(element, elementLength);
+            }
+          }
+        }
+      }
+    }
+  }
+  else if (data) {
+    _LOG_DEBUG("Received Data on face " << face->getFaceId() << ": " << data->getName());
+
+    // Send the data packet to the face for each matching PIT entry.
+    for (int i = 0; i < PIT_.size(); ++i) {
+      PitEntry& entry = *PIT_[i];
+      if (entry.getInFace() && entry.getInterest()->matchesData(*data)) {
+        _LOG_DEBUG("Forwarded Data to face " << entry.getInFace()->getFaceId()
+          << ": " << data->getName());
+        // Forward the full element including any LP header.
+        entry.getInFace()->send(element, elementLength);
+
+        // The PIT entry is consumed, so set clear the inFace_ which prevents
+        // using it to return another Data packet, but we keep the PIT entry to
+        // check for a duplicate nonce. It will be deleted after entryEndTime.
+        // (If a fresh Interest arrives with the same name, a new PIT entry will
+        // be created.)
+        entry.clearInFace();
+      }
+    }
+  }
+}
+
+MicroForwarder::ForwarderFace*
+MicroForwarder::findFace(int faceId)
+{
+  for (int i = 0; i < faces_.size(); ++i) {
+    if (faces_[i]->getFaceId() == faceId)
+      return faces_[i].get();
+  }
+
+  return 0;
+}
+
+int MicroForwarder::ForwarderFace::lastFaceId_ = 0;
+MicroForwarder* MicroForwarder::instance_ = 0;
+
+}


### PR DESCRIPTION
A MicroForwarder is an in-memory object with a PIT and a FIB and functionality similar to a full NDN forwarder. The application can create a Face to the MicroForwarder instead of a normal forwarder. (This is useful on systems that don't support NFD.) The application can create forwarder faces and routes.

This pull request has three commits. The first commit adds the `ElementListenerLite` class which exposes existing functionality in the public API so that it can be used by the MicroForwarder.

The second commit adds the `MicroForwarder` to the ndn-ind-tools library (which is always compiled and installed along with the main ndn-ind library).  It also adds the class `MicroForwarderTransport`. When the application creates a Face, it uses this to connect to the MicroForwarder.

The third commit updates the VisualStudio project to add the MicroForwarder files.