### PR TITLE
In MicroForwarder, drop a Nack for duplicate nonce

### DIFF
--- a/tools/micro-forwarder/micro-forwarder.cpp
+++ b/tools/micro-forwarder/micro-forwarder.cpp
@@ -185,6 +185,14 @@ MicroForwarder::onReceivedElement
       _LOG_DEBUG("Received Interest with Nack on face " << face->getFaceId() <<
         ": " << interest->getName());
 
+      if (networkNack->getReason() == ndn_NetworkNackReason_DUPLICATE) {
+        // Drom the Nack for duplicate nonce so we don't consume the PIT entry,
+        // but wait for the Data packet from the first successful interest.
+        _LOG_DEBUG("Dropped Interest with Nack for duplicate nonce on face " << face->getFaceId() <<
+          ": " << interest->getName());
+        return;
+      }
+
       // Send the packet to the face for each matching PIT entry.
       // Note that this is similar to returning a Data packet.
       for (int i = 0; i < PIT_.size(); ++i) {


### PR DESCRIPTION
This is an addendum to the MicroForwarder added in pull request #16. In the MicroForwarder, interests are multicasted by default. If a multicast interest is returned as a network Nack with reason "duplicate", then the forwarder should drop it. (This is the behavior of NFD.) This is so that it doesn't consume the PIT entry, and instead wait for the Data packet which is the response to the first interest which arrived at the producer. This pull request makes this change to the MicroForwarder.