### PR TITLE
In the Transport classes, the inner ConnectionInfo class also needs ndn_ind_dll

### DIFF
--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj
@@ -370,6 +370,7 @@
     <ClCompile Include="..\..\src\security\certificate\certificate-subject-description.cpp" />
     <ClCompile Include="..\..\src\security\certificate\certificate.cpp" />
     <ClCompile Include="..\..\src\security\certificate\public-key.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\x509-certificate-info.cpp" />
     <ClCompile Include="..\..\src\security\command-interest-preparer.cpp" />
     <ClCompile Include="..\..\src\security\command-interest-signer.cpp" />
     <ClCompile Include="..\..\src\security\key-chain.cpp" />

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
@@ -1043,5 +1043,8 @@
     <ClCompile Include="..\..\src\lite\encoding\element-reader-lite.cpp">
       <Filter>Source Files\src\lite\encoding</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\x509-certificate-info.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
@@ -39,7 +39,7 @@ public:
    * A MicroForwarderTransport::ConnectionInfo extends Transport::ConnectionInfo
    * to hold the MicroForwarder object to connect to.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo for the forwarder object.

--- a/include/ndn-ind/transport/async-tcp-transport.hpp
+++ b/include/ndn-ind/transport/async-tcp-transport.hpp
@@ -58,7 +58,7 @@ public:
    * An AsyncTcpTransport::ConnectionInfo extends Transport::ConnectionInfo to
    * hold the host and port info for the TCP connection.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo with the given host and port.

--- a/include/ndn-ind/transport/async-unix-transport.hpp
+++ b/include/ndn-ind/transport/async-unix-transport.hpp
@@ -60,7 +60,7 @@ public:
    * An AsyncUnixTransport::ConnectionInfo extends Transport::ConnectionInfo to
    * hold the file path of the Unix socket.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo with the given filePath.

--- a/include/ndn-ind/transport/tcp-transport.hpp
+++ b/include/ndn-ind/transport/tcp-transport.hpp
@@ -54,7 +54,7 @@ public:
    * A TcpTransport::ConnectionInfo extends Transport::ConnectionInfo to hold
    * the host and port info for the TCP connection.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo with the given host and port.

--- a/include/ndn-ind/transport/transport.hpp
+++ b/include/ndn-ind/transport/transport.hpp
@@ -50,7 +50,7 @@ public:
    * A Transport::ConnectionInfo is a base class for connection information used
    * by subclasses of Transport.
    */
-  class ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo {
   public:
     virtual ~ConnectionInfo();
   };

--- a/include/ndn-ind/transport/udp-transport.hpp
+++ b/include/ndn-ind/transport/udp-transport.hpp
@@ -54,7 +54,7 @@ public:
    * A UdpTransport::ConnectionInfo extends Transport::ConnectionInfo to hold
    * the host and port info for the UDP connection.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo with the given host and port.

--- a/include/ndn-ind/transport/unix-transport.hpp
+++ b/include/ndn-ind/transport/unix-transport.hpp
@@ -58,7 +58,7 @@ public:
    * A UnixTransport::ConnectionInfo extends Transport::ConnectionInfo to hold
    * the file path of the Unix socket.
    */
-  class ConnectionInfo : public Transport::ConnectionInfo {
+  class ndn_ind_dll ConnectionInfo : public Transport::ConnectionInfo {
   public:
     /**
      * Create a ConnectionInfo with the given filePath.


### PR DESCRIPTION
This is a follow-on to pull request #17 for Windows support. As explained there, classes need to be declared with `ndn_ind_dll`. But inner classes need it to. I found most places, but a few were missing which are the inner `ConnectionInfo` class of the Transport classes.

The second commit adds x509-certificate-info.cpp to the VisualStudio project (which should have been added in the pull request for X.509 support).