### PR TITLE
MicroForwarder: Support remote and local register prefix

### DIFF
--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder-transport.hpp
@@ -121,6 +121,8 @@ public:
   getIsConnected();
 
 private:
+  friend class MicroForwarder;
+
   /**
    * A MicroForwarderTransport::Endpoint extends Transport and is the the
    * Transport used in calling the MicroForwarder addFace method, as the endpoint
@@ -188,6 +190,8 @@ private:
     getIsConnected() { return true; }
 
   private:
+    friend class MicroForwarder;
+
     ndn::DynamicMallocUInt8ArrayLite elementBuffer_;
     ndn::ElementReaderLite elementReader_;
     MicroForwarderTransport* transport_;
@@ -198,6 +202,9 @@ private:
   ndn::DynamicMallocUInt8ArrayLite elementBuffer_;
   ndn::ElementReaderLite elementReader_;
   ndn::ptr_lib::shared_ptr<Endpoint> endpoint_;
+  bool isLocal_;
+  // Set outFaceId_ to specify the only output face for sending packets.
+  int outFaceId_;
 };
 
 }

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -24,6 +24,7 @@
 
 #include <ndn-ind/interest.hpp>
 #include <ndn-ind/data.hpp>
+#include <ndn-ind/face.hpp>
 #include <ndn-ind/transport/transport.hpp>
 
 namespace ndntools {
@@ -88,13 +89,30 @@ public:
   addRoute(const ndn::Name& name, int faceId, int cost = 0);
 
   /**
-   * @deprecated Use addRoute.
+   * Send a remote register prefix command over face with faceId to the remote
+   * forwarder. This allows the remote forwarder to forward interests back to
+   * here which match the prefix. On the remote node, nfd.conf must have a
+   * "localhop_security" section which allows remote prefix registration.
+   * @param faceId The face ID of the face for sending the command.
+   * @param prefix The prefix for remote registration. You can use the default
+   * Name() so that the remote forwarder will forward all interests to here, but
+   * if you want to limit the traffic, then use the prefix of the interests that
+   * the local application needs to receive.
+   * @param commandKeyChain The KeyChain object for signing command interests,
+   * which must remain valid until this calls onRegisterFailed or onRegisterSuccess.
+   * @param commandCertificateName The certificate name corresponding to the
+   * key in commandKeyChain which is used for signing command interests. This
+   * makes a copy of the Name. You can get the default certificate name with
+   * commandKeyChain.getDefaultCertificateName() .
+   * @param onRegisterFailed
+   * @param onRegisterSuccess
    */
-  bool
-  DEPRECATED_IN_NDN_IND registerRoute(const ndn::Name& name, int faceId, int cost = 0)
-  {
-    return addRoute(name, faceId, cost);
-  }
+  void
+  remoteRegisterPrefix
+    (int faceId, const ndn::Name& prefix, ndn::KeyChain& commandKeyChain,
+     const ndn::Name& commandCertificateName,
+     const ndn::OnRegisterFailed& onRegisterFailed,
+     const ndn::OnRegisterSuccess& onRegisterSuccess = ndn::OnRegisterSuccess());
 
   /**
    * Call processEvents() for the Transport object in each face. This is
@@ -159,6 +177,9 @@ private:
 
     const std::string&
     getUri() const { return uri_; }
+
+    ndn::Transport*
+    getTransport() const { return transport_.get(); }
 
     int
     getFaceId() const { return faceId_; }

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -85,7 +85,16 @@ public:
    * faceId.
    */
   bool
-  registerRoute(const ndn::Name& name, int faceId, int cost = 0);
+  addRoute(const ndn::Name& name, int faceId, int cost = 0);
+
+  /**
+   * @deprecated Use addRoute.
+   */
+  bool
+  DEPRECATED_IN_NDN_IND registerRoute(const ndn::Name& name, int faceId, int cost = 0)
+  {
+    return addRoute(name, faceId, cost);
+  }
 
   /**
    * Call processEvents() for the Transport object in each face. This is

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -90,6 +90,15 @@ public:
   addRoute(const ndn::Name& name, int faceId, int cost = 0);
 
   /**
+   * @deprecated Use addRoute.
+   */
+  bool
+  DEPRECATED_IN_NDN_IND registerRoute(const ndn::Name& name, int faceId, int cost = 0)
+  {
+    return addRoute(name, faceId, cost);
+  }
+
+  /**
    * Send a remote register prefix command over face with faceId to the remote
    * forwarder. This allows the remote forwarder to forward interests back to
    * here which match the prefix. On the remote node, nfd.conf must have a

--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -42,6 +42,7 @@ public:
   : minPitEntryLifetime_(std::chrono::minutes(1)),
     localhostNamePrefix("/localhost"),
     localhopNamePrefix("/localhop"),
+    registerNamePrefix("/localhost/nfd/rib/register"),
     broadcastNamePrefix("/ndn/broadcast")
   {
   }
@@ -395,6 +396,14 @@ private:
   };
 
   /**
+   * This is called by onReceivedElement when it receives an interest starting
+   * with /localhost . Process the localhost command such as register prefix.
+   */
+  void
+  onReceivedLocalhostInterest
+    (ForwarderFace* face, const ndn::ptr_lib::shared_ptr<ndn::Interest>& interest);
+
+  /**
    * Find the face in faces_ with the faceId.
    * @param The faceId.
    * @return The ForwarderFace, or null if not found.
@@ -420,6 +429,7 @@ private:
 
   ndn::Name localhostNamePrefix;
   ndn::Name localhopNamePrefix;
+  ndn::Name registerNamePrefix;
   ndn::Name broadcastNamePrefix;
 
   static MicroForwarder* instance_;

--- a/tools/micro-forwarder/micro-forwarder-transport.cpp
+++ b/tools/micro-forwarder/micro-forwarder-transport.cpp
@@ -37,14 +37,16 @@ MicroForwarderTransport::ConnectionInfo::~ConnectionInfo()
 
 MicroForwarderTransport::MicroForwarderTransport()
 : elementBuffer_(1000),
-  elementReader_(0, &elementBuffer_)
+  elementReader_(0, &elementBuffer_),
+  isLocal_(true),
+  outFaceId_(-1)
 {
 }
 
 bool
 MicroForwarderTransport::isLocal(const Transport::ConnectionInfo& connectionInfo)
 {
-  return true;
+  return isLocal_;
 }
 
 bool

--- a/tools/micro-forwarder/micro-forwarder-transport.cpp
+++ b/tools/micro-forwarder/micro-forwarder-transport.cpp
@@ -72,7 +72,7 @@ MicroForwarderTransport::connect
   // The MicroForwader will call endpoint_->connect with its elementListener.
   int faceId = connectionInfo_.getForwarder()->addFace
     ("internal://app", endpoint_, ptr_lib::make_shared<Transport::ConnectionInfo>());
-  connectionInfo_.getForwarder()->registerRoute(Name("/"), faceId);
+  connectionInfo_.getForwarder()->addRoute(Name("/"), faceId);
 
   if (onConnected)
     onConnected();

--- a/tools/micro-forwarder/micro-forwarder.cpp
+++ b/tools/micro-forwarder/micro-forwarder.cpp
@@ -62,11 +62,11 @@ MicroForwarder::addFace(const char *host, unsigned short port)
 }
 
 bool
-MicroForwarder::registerRoute(const ndn::Name& name, int faceId, int cost)
+MicroForwarder::addRoute(const Name& name, int faceId, int cost)
 {
   ForwarderFace* nextHopFace = findFace(faceId);
   if (!nextHopFace) {
-    _LOG_INFO("Register route: Unrecognized face id " << faceId);
+    _LOG_INFO("addRoute: Unrecognized face id " << faceId);
     return false;
   }
 
@@ -83,7 +83,7 @@ MicroForwarder::registerRoute(const ndn::Name& name, int faceId, int cost)
         // The face is not already added.
         fibEntry.addNextHop(ptr_lib::make_shared<NextHopRecord>(nextHopFace, cost));
 
-      _LOG_INFO("Register route: Added face " << faceId <<
+      _LOG_INFO("addRoute: Added face " << faceId <<
         " to existing FIB entry for: " << name);
       return true;
     }
@@ -94,7 +94,7 @@ MicroForwarder::registerRoute(const ndn::Name& name, int faceId, int cost)
   fibEntry->addNextHop(ptr_lib::make_shared<NextHopRecord>(nextHopFace, cost));
   FIB_.push_back(fibEntry);
 
-  _LOG_INFO("Register route: Added face id " << faceId <<
+  _LOG_INFO("addRoute: Added face id " << faceId <<
     " to new FIB entry for: " << name);
   return true;
 }


### PR DESCRIPTION
This is a follow-on to pull request #31 for the MicroForwarder. Currently, the application can configure the MicroForwarder with a route to another host and send an Interest. But the application cannot receive Interests. Our use case is where the application node does not have a public IP address. So, to receive interests from a remote node, we need to do a "remote prefix registration" with the NFD on the remote node.

This pull request has five commits. The first commit updates the MicroForwarder to rename the method `registerRoute` to `addRoute` since this operation is close to `nfdc add route` and we don't want to confuse it with prefix registration.

The second commit internally updates `MicroForwarderConnection` to make `MicroForwarder` a friend class and to add the variable `outFaceId_` which will be manipulated by the MicroForwarder as explained below.

The third commit updates the MicroForwarder with the method `remoteRegisterPrefix` for doing remote prefix registration with the NFD that is connected to by an existing forwarder face. This creates a temporary `MicroForwarderTransport` and sets its internal variable `outFaceId_` to the connection where we should send the NFD register prefix command. Then this creates a temporary `Face` and calls its `registerPrefix` which constructs the register prefix command, sends it and processes the response. We also update the MicroForwarder forwarding logic with the special case: If an Interest comes from a `MicroForwarderTransport` that specifies an `outFaceId_`, then only forward the interest to that face. This is how we ensure that the prefix registration command only goes to the intended NFD and is not multicast as a normal Interest.

So now we can do remote prefix registration and receive an Interest into the MicroForwarder. But the application still needs to receive it. When the application calls `registerPrefix` on its own application `Face`, it sends a prefix registration command Interest to the MicroForwarder which starts with `/localhost`. The fourth commit updates the MicroForwarder to process a `/localhost` prefix registration command similar to NFD by creating a face and route back to the application, which can now receive the `OnInterest` callback and process the Interest as usual.

Finally, the fifth commit updates the forwarding logic so that if an Interest matches multiple prefixes which forward to the same face, then make sure that the Interest is not forwarded more than once to the same face.