### PR TITLE
Support NDN name in X.509 certificate Subject Alternative Names

### DIFF
--- a/include/ndn-ind/security/certificate/x509-certificate-info.hpp
+++ b/include/ndn-ind/security/certificate/x509-certificate-info.hpp
@@ -114,25 +114,35 @@ public:
   }
 
   /**
-   * Convert an X.509 name to an NDN Name. This should be the reverse operation
-   * of makeX509Name().
-   * @param x509Name The DerNode of the X.509 name.
+   * Make an NDN Name from the URI field in the Subject Alternative Names
+   * extension, if available. Otherwise make an NDN name that encapsulates the
+   * X.509 name, where the first component is "x509" and the second is the
+   * encoded X.509 name. This should be the reverse operation of makeX509Name().
+   * @param x509Name The DerNode of the X.509 name, used if extensions is null
+   * or doesn't have a URI field in the Subject Alternative Names.
+   * @param extensions The DerNode of the extensions (the only child of the
+   * DerExplicit node with tag 3). If this is null, don't use it.
    * @return The NDN Name.
    */
   static Name
-  makeName(DerNode& x509Name);
+  makeName(DerNode* x509Name, DerNode* extensions);
 
   /**
-   * If the Name has two components and the first is "x509", then return the
-   * DerNode of the second component. Otherwise, return the DerNode of an
-   * X.509 name with one component where the type is "pseudonym" and the value
-   * is a UTF8 string with the name URI. This should be the reverse operation
-   * of makeName().
+   * If the Name has two components and the first is "x509" (see
+   * isEncapsulatedX509), then return a DerNode made from the second component.
+   * Otherwise, return a DerNode which is a short representation of the Name,
+   * and update the extensions by adding a Subject Alternative Names extension
+   * with a URI field for the NDN Name. This should be the reverse operation of
+   * makeName().
    * @param name The NDN name.
+   * @param extensions The DerNode of the extensions (the only child of the
+   * DerExplicit node with tag 3). If the NDN Name is not an encapsulated X.509
+   * name, then add the Subject Alternative Names extensions (without first
+   * checking if extensions already has one). If this is null, don't use it.
    * @return A DerNode of the X.509 name.
    */
   static ptr_lib::shared_ptr<DerNode>
-  makeX509Name(const Name& name);
+  makeX509Name(const Name& name, DerNode* extensions);
 
   /**
    * Get the name component for "x509". This is a method because not all C++

--- a/src/encoding/der/der-node.cpp
+++ b/src/encoding/der/der-node.cpp
@@ -98,6 +98,8 @@ DerNode::parse(const uint8_t* inputBuf, size_t inputBufLength, size_t startIdx)
     newNode.reset(new DerGeneralizedTime());
   else if (DerStructure::isExplicitNode(nodeType))
     newNode.reset(new DerExplicit(nodeType & 0x1f));
+  else if (DerImplicitByteString::isImplicit(nodeType))
+    newNode.reset(new DerImplicitByteString(nodeType));
   else
     throw DerDecodingException("Unimplemented DER type");
 

--- a/src/security/certificate/x509-certificate-info.cpp
+++ b/src/security/certificate/x509-certificate-info.cpp
@@ -30,6 +30,8 @@ typedef DerNode::DerSequence DerSequence;
 
 static const char *RSA_ENCRYPTION_OID = "1.2.840.113549.1.1.1";
 static const char *PSEUDONYM_OID = "2.5.4.65";
+static const char *SUBJECT_ALTERNATIVE_NAME_OID = "2.5.29.17";
+static const int SUBJECT_ALTERNATIVE_NAME_URI_TYPE = 0x86;
 
 X509CertificateInfo::X509CertificateInfo(const Blob& encoding)
 {
@@ -95,7 +97,7 @@ X509CertificateInfo::X509CertificateInfo(const Blob& encoding)
     if (tbsChildren.size() < 6 + versionOffset)
       throw runtime_error("X509CertificateInfo: Expected 6 TBSCertificate fields");
 
-    issuerName_ = makeName(*tbsChildren[2 + versionOffset]);
+    issuerName_ = makeName(tbsChildren[2 + versionOffset].get(), 0);
 
     // validity
     const vector<ptr_lib::shared_ptr<DerNode> >& validityChildren =
@@ -108,7 +110,15 @@ X509CertificateInfo::X509CertificateInfo(const Blob& encoding)
       throw runtime_error("X509CertificateInfo: Cannot decode Validity");
     validityPeriod_ = ValidityPeriod(notBefore->toTimePoint(), notAfter->toTimePoint());
 
-    subjectName_ = makeName(*tbsChildren[4 + versionOffset]);
+    // Get the extensions.
+    DerNode* extensions = 0;
+    DerNode::DerExplicit* extensionsExplicit = dynamic_cast<DerNode::DerExplicit*>
+      (tbsChildren[tbsChildren.size() - 1].get());
+    if (extensionsExplicit && extensionsExplicit->getTag() == 3 &&
+        extensionsExplicit->getChildren().size() == 1)
+      extensions = extensionsExplicit->getChildren()[0].get();
+
+    subjectName_ = makeName(tbsChildren[4 + versionOffset].get(), extensions);
 
     publicKey_ = tbsChildren[5 + versionOffset]->encode();
   } catch (const std::exception& ex) {
@@ -123,12 +133,17 @@ X509CertificateInfo::X509CertificateInfo
 : issuerName_(issuerName), validityPeriod_(validityPeriod),
   subjectName_(subjectName), publicKey_(publicKey), signatureValue_(signatureValue)
 {
+  // We are using certificate extensions, so we must set the version.
+  ptr_lib::shared_ptr<DerNode::DerExplicit> version(new DerNode::DerExplicit(0));
+  version->addChild(ptr_lib::make_shared<DerNode::DerInteger>(2));
+
   ptr_lib::shared_ptr<DerSequence> algorithmIdentifier(new DerSequence());
   algorithmIdentifier->addChild(ptr_lib::make_shared<DerNode::DerOid>(RSA_ENCRYPTION_OID));
   algorithmIdentifier->addChild(ptr_lib::make_shared<DerNode::DerNull>());
 
   ptr_lib::shared_ptr<DerSequence> tbsCertificate(new DerSequence());
   //TBSCertificate  ::=  SEQUENCE  {
+  //      version         [0]  EXPLICIT Version DEFAULT v1,
   //      serialNumber         CertificateSerialNumber,
   //      signature            AlgorithmIdentifier,
   //      issuer               Name,
@@ -136,9 +151,10 @@ X509CertificateInfo::X509CertificateInfo
   //      subject              Name,
   //      subjectPublicKeyInfo SubjectPublicKeyInfo
   //      }
+  tbsCertificate->addChild(version);
   tbsCertificate->addChild(ptr_lib::make_shared<DerNode::DerInteger>(0));
   tbsCertificate->addChild(algorithmIdentifier);
-  tbsCertificate->addChild(makeX509Name(issuerName));
+  tbsCertificate->addChild(makeX509Name(issuerName, 0));
 
   ptr_lib::shared_ptr<DerSequence> validity(new DerSequence());
   validity->addChild(ptr_lib::make_shared<DerNode::DerUtcTime>
@@ -147,13 +163,22 @@ X509CertificateInfo::X509CertificateInfo
     (validityPeriod.getNotAfter()));
   tbsCertificate->addChild(validity);
 
-  tbsCertificate->addChild(makeX509Name(subjectName));
+  ptr_lib::shared_ptr<DerSequence> extensions(new DerSequence());
+  tbsCertificate->addChild(makeX509Name(subjectName, extensions.get()));
 
   try {
     tbsCertificate->addChild(DerNode::parse(publicKey));
   } catch (const std::exception& ex) {
     throw runtime_error(string("X509CertificateInfo: publicKey encoding is invalid DER: ") +
       ex.what());
+  }
+
+  if (extensions->getChildren().size() > 0) {
+    // makeX509Name added to extensions, so include it.
+    ptr_lib::shared_ptr<DerNode::DerExplicit> extensionsExplicit
+      (new DerNode::DerExplicit(3));
+    extensionsExplicit->addChild(extensions);
+    tbsCertificate->addChild(extensionsExplicit);
   }
 
   // Certificate  ::=  SEQUENCE  {
@@ -173,56 +198,127 @@ X509CertificateInfo::X509CertificateInfo
 }
 
 Name
-X509CertificateInfo::makeName(DerNode& x509Name)
+X509CertificateInfo::makeName(DerNode* x509Name, DerNode* extensions)
 {
-  // Check if there is a UTF8 string with the OID for "pseudonym".
-  const vector<ptr_lib::shared_ptr<DerNode> >& components = x509Name.getChildren();
-  for (int i = 0; i < components.size(); ++i) {
-    DerNode::DerSet* component = dynamic_cast<DerNode::DerSet*>(components[i].get());
-    if (!component)
-      // Not a valid X.509 name. Don't worry about it and continue below to use the encoding.
-      break;
-    const vector<ptr_lib::shared_ptr<DerNode> >& componentChildren =
-      component->getChildren();
-    if (componentChildren.size() != 1)
-      break;
-    DerSequence* typeAndValue = dynamic_cast<DerSequence*>(componentChildren[0].get());
-    if (!typeAndValue)
-      break;
-    const vector<ptr_lib::shared_ptr<DerNode> >& typeAndValueChildren =
-      typeAndValue->getChildren();
-    if (typeAndValueChildren.size() != 2)
-      break;
+  if (extensions) {
+    // Try to get the URI field in the Subject Alternative Names.
 
-    DerNode::DerOid* oid = dynamic_cast<DerNode::DerOid*>(typeAndValueChildren[0].get());
-    DerNode::DerUtf8String* value = dynamic_cast<DerNode::DerUtf8String*>
-      (typeAndValueChildren[1].get());
+    //Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
+    //
+    // Extension  ::=  SEQUENCE  {
+    //    extnID      OBJECT IDENTIFIER,
+    //    critical    BOOLEAN DEFAULT FALSE,
+    //    extnValue   OCTET STRING
+    //                -- contains the DER encoding of an ASN.1 value
+    //                -- corresponding to the extension type identified
+    //                -- by extnID
+    //    }
+    //
+    // subjectAltName EXTENSION ::= {
+    // 	SYNTAX GeneralNames
+    // 	IDENTIFIED BY id-ce-subjectAltName
+    // }
+    //
+    // GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+    //
+    // GeneralName ::= CHOICE {
+    // 	otherName	[0] INSTANCE OF OTHER-NAME,
+    // 	rfc822Name	[1] IA5String,
+    // 	dNSName		[2] IA5String,
+    // 	x400Address	[3] ORAddress,
+    // 	directoryName	[4] Name,
+    // 	ediPartyName	[5] EDIPartyName,
+    // 	uniformResourceIdentifier [6] IA5String,
+    // 	IPAddress	[7] OCTET STRING,
+    // 	registeredID	[8] OBJECT IDENTIFIER
+    const vector<ptr_lib::shared_ptr<DerNode> >& extensionsChildren =
+      extensions->getChildren();
 
-    if (oid && value && oid->toVal().toRawStr() == PSEUDONYM_OID)
-      return Name(value->toVal().toRawStr());
+    for (int i = 0; i < extensionsChildren.size(); ++i) {
+      DerSequence* extension = dynamic_cast<DerSequence*>(extensionsChildren[i].get());
+      if (!extension)
+        // We don't expect this.
+        continue;
+      const vector<ptr_lib::shared_ptr<DerNode> >& extensionChildren =
+        extension->getChildren();
+
+      if (extensionChildren.size() < 2 || extensionChildren.size() > 3)
+        // We don't expect this.
+        continue;
+      DerNode::DerOid* oid = dynamic_cast<DerNode::DerOid*>(extensionChildren[0].get());
+      // Ignore "critical".
+      DerNode::DerOctetString* extensionValue = dynamic_cast<DerNode::DerOctetString*>
+        (extensionChildren[extensionChildren.size() - 1].get());
+      if (!oid || !extensionValue)
+        // We don't expect this.
+        continue;
+      if (oid->toVal().toRawStr() != SUBJECT_ALTERNATIVE_NAME_OID)
+        // Try the next extension.
+        continue;
+
+      try {
+        ptr_lib::shared_ptr<DerNode> generalNames = DerNode::parse(extensionValue->toVal());
+        const vector<ptr_lib::shared_ptr<DerNode> >& generalNamesChildren =
+          generalNames->getChildren();
+        for (int i = 0; i < generalNamesChildren.size(); ++i) {
+          DerNode::DerImplicitByteString* value =
+            dynamic_cast<DerNode::DerImplicitByteString*>(generalNamesChildren[i].get());
+          if (!value)
+            // We don't expect this.
+            continue;
+
+          if (value->getType() == SUBJECT_ALTERNATIVE_NAME_URI_TYPE)
+            // Return an NDN name made from the URI.
+            return Name(value->toVal().toRawStr());
+        }
+      } catch (const std::exception& ex) {
+        // We don't expect this.
+        continue;
+      }
+    }
   }
-  
-  return Name().append(getX509_COMPONENT()).append(x509Name.encode());
+
+  // Default behavior: Encapsulate the X.509 name.
+  return Name().append(getX509_COMPONENT()).append(x509Name->encode());
 }
 
 ptr_lib::shared_ptr<DerNode>
-X509CertificateInfo::makeX509Name(const Name& name)
+X509CertificateInfo::makeX509Name(const Name& name, DerNode* extensionsNode)
 {
   if (isEncapsulatedX509(name))
     // Just decode the second component.
     return DerNode::parse(name.get(1).getValue());
 
-  // Make an X.509 name with an "pseudonym.
+  string uri = name.toUri();
+  DerSequence* extensions = dynamic_cast<DerSequence*>(extensionsNode);
+  if (extensions) {
+    // Add the Subject Alternative Names without checking if one already exists.
+    DerSequence generalNames;
+    generalNames.addChild(ptr_lib::make_shared<DerNode::DerImplicitByteString>
+      ((const uint8_t*)uri.c_str(), uri.size(), SUBJECT_ALTERNATIVE_NAME_URI_TYPE));
+    Blob generalNamesEncoding = generalNames.encode();
+
+    ptr_lib::shared_ptr<DerSequence> extension(new DerSequence());
+    extension->addChild(ptr_lib::make_shared<DerNode::DerOid>
+      (OID(SUBJECT_ALTERNATIVE_NAME_OID)));
+    extension->addChild(ptr_lib::make_shared<DerNode::DerOctetString>
+      (generalNamesEncoding.buf(), generalNamesEncoding.size()));
+    extensions->addChild(extension);
+  }
+
+  // Make an X.509 name with a "pseudonym". This is only temporary because in
+  // production the X.509 certificate is created specially with a separate
+  // X.509 name with an NDN name in Subject Alternative Names.
   ptr_lib::shared_ptr<DerSequence> root(new DerSequence());
   ptr_lib::shared_ptr<DerSequence> typeAndValue(new DerSequence());
   typeAndValue->addChild(ptr_lib::make_shared<DerNode::DerOid>(OID(PSEUDONYM_OID)));
-  string uri = name.toUri();
   typeAndValue->addChild(ptr_lib::make_shared<DerNode::DerUtf8String>
     ((const uint8_t*)uri.c_str(), uri.size()));
   ptr_lib::shared_ptr<DerNode::DerSet> component(new DerNode::DerSet());
   component->addChild(typeAndValue);
 
   root->addChild(component);
+
   return root;
 }
 


### PR DESCRIPTION
This is a follow-on to pull request #35 to support an NDN name placed in the X.509 certificate's extensions as a URI field in the Subject Alternative Names.

This pull request has two commits. The first commit updates the `DerNode` encoder/decoder with the support class `DerImplicitByteString` . This is needed because the URI field is encoded with an IMPLICIT type.

The second commit updates the class `X509CertificateInfo` so that the utility methods [makeName](https://github.com/operantnetworks/ndn-ind/blob/b00eb477e22b91fec30dac94e7c26c818fb6d9de/include/ndn-ind/security/certificate/x509-certificate-info.hpp#L116-L128) and [makeX509Name](https://github.com/operantnetworks/ndn-ind/blob/b00eb477e22b91fec30dac94e7c26c818fb6d9de/include/ndn-ind/security/certificate/x509-certificate-info.hpp#L116-L128) support an NDN name as a URI field in the Subject Alternative Names extension. See the method description for more detail.