### PR TITLE
MicroForwarder: Catch and log errors in transport send

### DIFF
--- a/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
+++ b/include/ndn-ind-tools/micro-forwarder/micro-forwarder.hpp
@@ -213,11 +213,7 @@ private:
      * @param dataLength The number of bytes in data.
      */
     void
-    send(const uint8_t *data, size_t dataLength)
-    {
-      if (transport_)
-        transport_->send(data, dataLength);
-    }
+    send(const uint8_t *data, size_t dataLength);
 
     void
     send(const std::vector<uint8_t>& data) { send(&data[0], data.size()); }

--- a/tools/micro-forwarder/micro-forwarder.cpp
+++ b/tools/micro-forwarder/micro-forwarder.cpp
@@ -146,6 +146,20 @@ MicroForwarder::processEvents()
 }
 
 void
+MicroForwarder::ForwarderFace::send(const uint8_t *data, size_t dataLength)
+{
+  if (transport_) {
+    try {
+      transport_->send(data, dataLength);
+    } catch (const std::exception& ex) {
+      _LOG_ERROR("MicroForwarder: Error in transport send: " << ex.what());
+    } catch (...) {
+      _LOG_ERROR("MicroForwarder: Error in transport send");
+    }
+  }
+}
+
+void
 MicroForwarder::ForwarderFace::onReceivedElement
   (const uint8_t *element, size_t elementLength)
 {


### PR DESCRIPTION
This is a stability update for the MicroForwarder. If the link for a face is down, then send may cause an error. This pull request catches and logs errors, but lets the MicroForwarder continue functioning.