### PR TITLE
In EncryptorV2, check again for isKeyReady

### DIFF
--- a/src/encrypt/encryptor-v2.cpp
+++ b/src/encrypt/encryptor-v2.cpp
@@ -208,6 +208,11 @@ EncryptorV2::Impl::encrypt
 {
   // Use the first key manager in the prioritized list which has a ready key.
   for (size_t i = 0; i < keyManagers_.size(); ++i) {
+    // Below, encrypt only checks if a first GCK has been retrieved. We must also
+    // check isKeyReady() to make sure the access manager is responding.
+    if (!keyManagers_[i]->isKeyReady())
+      continue;
+
     ptr_lib::shared_ptr<EncryptedContent> encryptedContent = keyManagers_[i]->encrypt
       (plainData, plainDataLength, associatedData, associatedDataLength);
     if (encryptedContent)


### PR DESCRIPTION
When a remote key manager goes offline, EncryptorV2 sets isKeyReady to false for the related internal `KeyManager`. When we encrypt, there is already logic to check if the first content key has been retrieved. But we need extra to check isKeyReady each time before using a content key to encrypt.