### PR TITLE
In the MicroForwarder, allow re-forwarding a duplicate interest

### DIFF
--- a/tools/micro-forwarder/micro-forwarder.cpp
+++ b/tools/micro-forwarder/micro-forwarder.cpp
@@ -297,10 +297,6 @@ MicroForwarder::onReceivedElement
     PIT_.push_back(pitEntry);
     _LOG_DEBUG("Added PIT entry for Interest: " << interest->getName());
 
-    if (isDuplicateInterest)
-      // Don't forward a duplicate interest.
-      return;
-
     if (broadcastNamePrefix.match(interest->getName())) {
       // Special case: broadcast to all faces.
       for (int i = 0; i < faces_.size(); ++i) {


### PR DESCRIPTION
When the MicroForwarder receives an interest, it creates a PIT entry with a timeout. If it receives a duplicate interest with the same name (but different nonce), it "aggregates" into the PIT entry but updating the PIT entry's timeout and continues to wait for the response Data packet. In this case, the MicroForwarder currently does not forward the duplicate Interest. This is an optimization and is not strictly necessary since the system will still function if a duplicate Interest is forwarded. It makes sense if the response Data packet is received.

But if the response Data packet is not received (because the responder is not responding) then there can be a problem if the application keeps re-sending the timed-out interests but the MicroForwarder sees it as a duplicate and doesn't forward it. There is some subtle timing logic which we need to examine to get this right. In the mean time, the safe thing is to remove this optimization and allow the application to send a duplicate Interest through the MicroForwarder.