### PR TITLE
In EncryptorV2, if no access managers respond, use the one from the last encryption. 

### DIFF
--- a/include/ndn-ind/encrypt/encryptor-v2.hpp
+++ b/include/ndn-ind/encrypt/encryptor-v2.hpp
@@ -651,6 +651,9 @@ private:
       size_t
       size() { return storage_.size(); }
 
+      const Name&
+      getAccessPrefix() const { return accessPrefix_; }
+
     private:
       // Give friend access to the tests.
       friend class ::TestEncryptorV2_EncryptAndPublishCk_Test;
@@ -764,6 +767,8 @@ private:
     Face* face_;
     ndn_EncryptAlgorithmType algorithmType_;
     std::vector<ptr_lib::shared_ptr<KeyManager> > keyManagers_;
+    // The index in keyManagers_ of the last successful encryption.
+    int iKeyManagerLastEncryption_;
     // A historical record mapping the generated CK name or fetched GCK name to
     // the content key.
     std::map<Name, Blob> contentKeys_;


### PR DESCRIPTION
EncryptorV2 keeps a list of key managers and periodically check if they are responding. If one doesn't respond, EncryptorV2 switches to the next one in the list. But this logic didn't consider what to do if no key manager is responding. Currently, it will add to the pending encryption queue, waiting for a key manager to start responding. But this could last a very long time and is not the intended behavior. (If the application depends on the result of an encrypt operation, it can appear to freeze as each encrypt operation is added to the queue.)

This pull request updates EncryptorV2 as follows: On each successful encrypt operation, it sets `iKeyManagerLastEncryption_` to the index in the list of key managers. If all key managers stop responding, continue encrypting using the content key from the key manager at `iKeyManagerLastEncryption_` . (When any key manager starts responding again, continue with the original logic to select it.)