### PR TITLE
Face: If no unistd.h, compile the default constructor with exception

### DIFF
--- a/src/face.cpp
+++ b/src/face.cpp
@@ -88,6 +88,12 @@ Face::Face()
   commandKeyChain_(0)
 {
 }
+#else
+Face::Face()
+{
+  throw runtime_error
+    ("The default Face constructor for Unix sockets is not supported. Try Face(\"127.0.0.1\").");
+}
 #endif
 
 Face::Face(const char *host, unsigned short port)


### PR DESCRIPTION
The default Face constructor is for connecting to the local NFD using Unix sockets. Windows and other systems without unistd.h can't do this. In this case, the library simply doesn't compile the default Face constructor. If an example has this as an option, then the example will have a linker failure. This pull request changes this case to compile the default Face constructor, but to throw an exception. Therefore, the examples will compile and link.