### PR TITLE
For non-log4cxx, allow NDN_IND_WITH_LOGGING. Use for all log levels

### DIFF
--- a/include/ndn-ind/util/logging.hpp
+++ b/include/ndn-ind/util/logging.hpp
@@ -83,32 +83,38 @@ INIT_LOGGERS ();
 #else // else NDN_IND_HAVE_LOG4CXX
 
 #define INIT_LOGGER(name)
+#define INIT_LOGGERS(x)
 #define _LOG_FUNCTION(x)
 #define _LOG_FUNCTION_NOARGS
-#define _LOG_TRACE(x)
-#define _LOG_INFO(x)
-#define _LOG_WARN(x)
-#define _LOG_ERROR(x)
-#define INIT_LOGGERS(x)
-#define _LOG_ERROR_COND(cond,x)
-#define _LOG_DEBUG_COND(cond,x)
 
 #define MEMBER_LOGGER
 #define INIT_MEMBER_LOGGER(className,name)
 
-#ifdef _DEBUG
+// If the library is not compiled with _DEBUG, it is also possible to define
+// NDN_IND_WITH_LOGGING to send all log messages to clog.
+#if 1 || defined(_DEBUG) || defined(NDN_IND_WITH_LOGGING)
 
 #include <time.h>
 #include <iostream>
 
 #define _LOG_DEBUG(x) \
   { time_t now = time(0); std::string s = std::string(ctime(&now)); std::clog << s.substr(0, s.size() - 1) << " " << x << std::endl; }
-#define _LOG_ERROR(x) _LOG_DEBUG(x)
 
 #else
 #define _LOG_DEBUG(x)
-#define _LOG_ERROR(x)
 #endif
+
+// Define all the other levels using _LOG_DEBUG.
+#define _LOG_TRACE(x) _LOG_DEBUG(x)
+#define _LOG_INFO(x) _LOG_DEBUG(x)
+#define _LOG_WARN(x) _LOG_DEBUG(x)
+#define _LOG_ERROR(x) _LOG_DEBUG(x)
+
+#define _LOG_ERROR_COND(cond,x) \
+  if (cond) { _LOG_ERROR(x) }
+
+#define _LOG_DEBUG_COND(cond,x) \
+  if (cond) { _LOG_DEBUG(x) }
 
 #endif // NDN_IND_HAVE_LOG4CXX
 


### PR DESCRIPTION
If log4cxx is installed and enabled, then ndn-ind uses it for log output. If not, then it uses the second part of logging.hpp . Currently, it only prints log messages if `_DEBUG` is defined, but we also want the option if the library is not compiled in the debug configuration.

This pull request changes logging.hpp to also print log messages if `NDN_IND_WITH_LOGGING` is defined. It also uses the macro for `_LOG_DEBUG` for printing all log levels (not just DEBUG and ERROR).