### PR TITLE
In validate, check the CRL if the packet is a certificate

### DIFF
--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj
@@ -371,6 +371,7 @@
     <ClCompile Include="..\..\src\security\certificate\certificate.cpp" />
     <ClCompile Include="..\..\src\security\certificate\public-key.cpp" />
     <ClCompile Include="..\..\src\security\certificate\x509-certificate-info.cpp" />
+    <ClCompile Include="..\..\src\security\certificate\x509-crl-info.cpp" />
     <ClCompile Include="..\..\src\security\command-interest-preparer.cpp" />
     <ClCompile Include="..\..\src\security\command-interest-signer.cpp" />
     <ClCompile Include="..\..\src\security\key-chain.cpp" />
@@ -418,6 +419,8 @@
     <ClCompile Include="..\..\src\security\v2\validator-config\config-name-relation.cpp" />
     <ClCompile Include="..\..\src\security\v2\validator-config\config-rule.cpp" />
     <ClCompile Include="..\..\src\security\v2\validator.cpp" />
+    <ClCompile Include="..\..\src\security\v2\x509-crl-cache.cpp" />
+    <ClCompile Include="..\..\src\security\v2\x509-crl-fetcher.cpp" />
     <ClCompile Include="..\..\src\security\validator-null.cpp" />
     <ClCompile Include="..\..\src\security\validity-period.cpp" />
     <ClCompile Include="..\..\src\security\verification-helpers.cpp" />

--- a/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
+++ b/VisualStudio/ndn-ind/ndn-ind.vcxproj.filters
@@ -1046,5 +1046,14 @@
     <ClCompile Include="..\..\src\security\certificate\x509-certificate-info.cpp">
       <Filter>Source Files\src\security\certificate</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\x509-crl-cache.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\v2\x509-crl-fetcher.cpp">
+      <Filter>Source Files\src\security\v2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\security\certificate\x509-crl-info.cpp">
+      <Filter>Source Files\src\security\certificate</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/include/ndn-ind/security/v2/certificate-storage.hpp
+++ b/include/ndn-ind/security/v2/certificate-storage.hpp
@@ -183,17 +183,17 @@ public:
   }
 
   /**
-   * Find the first entry in crlInfo where the entry's serial number matches the
-   * given serial number.
-   * @param crlInfo The X509CrlInfo to search.
+   * Find the first entry in the CRL for issuerName where the entry's serial
+   * number matches the given serial number.
+   * @param issuerName The NDN issuer name for finding the CRL.
    * @param serialNumber The serial number to match as a Blob with the bytes of
    * the integer. If serialNumber.size() == 0, this does not match it.
    * @return The matching RevokedCertificate entry, or null if not found. The
    * pointer to the entry becomes invalid if the crlInfo is changed, so make a
    * copy if you need it long-term.
    */
-  static const X509CrlInfo::RevokedCertificate*
-  findRevokedCertificate(const X509CrlInfo& crlInfo, const Blob& serialNumber);
+  const X509CrlInfo::RevokedCertificate*
+  findRevokedCertificate(const Name& issuerName, const Blob& serialNumber) const;
 
 private:
   // Disable the copy constructor and assignment operator.

--- a/include/ndn-ind/security/v2/validation-state.hpp
+++ b/include/ndn-ind/security/v2/validation-state.hpp
@@ -69,6 +69,8 @@ typedef func_lib::function<void
   (const Interest& interest, const ValidationError& error)>
   InterestValidationFailureCallback;
 
+class CertificateStorage;
+
 /**
  * ValidationState is an abstract base class for DataValidationState and
  * InterestValidationState.
@@ -179,9 +181,14 @@ private:
    * Verify the signature of the original packet. This is only called by the
    * Validator class.
    * @param trustedCertificate The certificate that signs the original packet.
+   * @param certificateStorage If not null and the original packet is a
+   * CertificateV2, call certificateStorage.findRevokedCertificate to check if
+   * the original packet is revoked.
    */
   virtual void
-  verifyOriginalPacket(const CertificateV2& trustedCertificate) = 0;
+  verifyOriginalPacket
+    (const CertificateV2& trustedCertificate,
+     const CertificateStorage* certificateStorage) = 0;
 
   /**
    * Call the success callback of the original packet without signature
@@ -253,7 +260,9 @@ public:
 
 private:
   virtual void
-  verifyOriginalPacket(const CertificateV2& trustedCertificate);
+  verifyOriginalPacket
+    (const CertificateV2& trustedCertificate,
+     const CertificateStorage* certificateStorage);
 
   virtual void
   bypassValidation();
@@ -306,7 +315,9 @@ public:
 
 private:
   virtual void
-  verifyOriginalPacket(const CertificateV2& trustedCertificate);
+  verifyOriginalPacket
+    (const CertificateV2& trustedCertificate,
+     const CertificateStorage* certificateStorage);
 
   virtual void
   bypassValidation();

--- a/include/ndn-ind/security/v2/validator.hpp
+++ b/include/ndn-ind/security/v2/validator.hpp
@@ -109,6 +109,7 @@ public:
   /**
    * Asynchronously validate the Data packet.
    * @param data The Data packet to validate, which is copied.
+   * If data is a CertificateV2, then also check if it is revoked by the CRL.
    * @param successCallback On validation success, this calls
    * successCallback(data).
    * @param failureCallback On validation failure, this calls

--- a/src/security/v2/validator.cpp
+++ b/src/security/v2/validator.cpp
@@ -145,7 +145,7 @@ Validator::requestCertificate
         }
       }
 
-      state->verifyOriginalPacket(*certificate);
+      state->verifyOriginalPacket(*certificate, this);
     }
 
     return;

--- a/src/security/v2/x509-crl-fetcher.cpp
+++ b/src/security/v2/x509-crl-fetcher.cpp
@@ -78,7 +78,7 @@ X509CrlFetcher::Impl::checkForNewCrl()
 
     void
     onData
-      (const ptr_lib::shared_ptr<const Interest>& ckInterest,
+      (const ptr_lib::shared_ptr<const Interest>& interest,
        const ptr_lib::shared_ptr<Data>& crlLatestData)
     {
       parent_->lastResponseTime_ = system_clock::now();
@@ -103,13 +103,13 @@ X509CrlFetcher::Impl::checkForNewCrl()
             return;
           }
 
-          // Leave isGckRetrievalInProgress_ true.
+          // Leave isCrlRetrievalInProgress_ true.
           parent_->fetchCrl
             (newCrlName, 0, N_RETRIES, ptr_lib::make_shared<vector<Blob> >());
         },
         [=](auto&, auto& error) {
           parent_->isCrlRetrievalInProgress_ = false;
-          _LOG_ERROR("Validate CRL latest_ Data failure: " << error.toString());
+          _LOG_ERROR("Validate CRL _latest Data failure: " << error.toString());
         });
     }
 
@@ -192,6 +192,7 @@ X509CrlFetcher::Impl::fetchCrl
         int segment = segmentData->getName().get(-1).toSegment();
         if (segment != expectedSegment_) {
           // Since we fetch in sequence, we don't expect this.
+          parent_->isCrlRetrievalInProgress_ = false;
           _LOG_ERROR("fetchCrl: Expected segment " << expectedSegment_ <<
             ", but got " << segmentData->getName().toUri());
           return;


### PR DESCRIPTION
This is a follow-on to pull request #48 which updates the Validator to use the CRL to check if a fetched certificate is revoked. But there is another case where the packet given to the `validate` method is a certificate (instead of an Interest or a normal Data packet). This certificate should also be checked for revocation.

This pull request has three commits. The first commit changes `CertificateStorage::findRevokedCertificate` from a static method to a member method of `CertificateStorage` so that it can access the CRL when it is called by `verifyOriginalPacket`.

The second commit updates the virtual method `ValidationState::verifyOriginalPacket` to add the parameter `certificateStorage`. If the original packet is a certificate ,then `DataValidationState::verifyOriginalPacket` calls `certificateStorage->findRevokedCertificate` to check if it is revoked. (Note that this commit is similar to the fifth commit in the JavaScript pull request at https://github.com/operantnetworks/ndn-direct-ind/pull/27 .)

The third commit updates the VisualStudio project file ndn-ind.vcxproj to add the source files for `X509CrlCache`, `X509CrlFetcher` and `X509CrlInfo`. (This should have been done in the previous pull request.)