### PR TITLE
ValidationError: Rename NO_ERROR to NO_VALIDATION_ERROR

### DIFF
--- a/include/ndn-ind/security/v2/validation-error.hpp
+++ b/include/ndn-ind/security/v2/validation-error.hpp
@@ -45,7 +45,7 @@ namespace ndn {
  */
 class ndn_ind_dll ValidationError {
 public:
-  static const int NO_ERROR =                    0;
+  static const int NO_VALIDATION_ERROR =                    0;
   static const int INVALID_SIGNATURE =           1;
   static const int NO_SIGNATURE =                2;
   static const int CANNOT_RETRIEVE_CERTIFICATE = 3;

--- a/src/security/v2/validation-error.cpp
+++ b/src/security/v2/validation-error.cpp
@@ -44,7 +44,7 @@ operator<<(ostream& os, const ValidationError& error)
 {
   int code = error.getCode();
 
-  if (code == ValidationError::NO_ERROR)
+  if (code == ValidationError::NO_VALIDATION_ERROR)
     os << "No error";
   else if (code == ValidationError::INVALID_SIGNATURE)
     os << "Invalid signature";


### PR DESCRIPTION
`ValidationError` defines several constants including `NO_ERROR`. This can conflict with winerror.h on Windows which has a `#define` for `NO_ERROR`. This pull request renames it to `NO_VALIDATION_ERROR` to avoid conflict in a Windows application which also includes winerror.h . This should have minimal impact: Normally an NDN application does not use `ValidationError` constants directly, but uses the error string output. Also, an application normally would not check for the "no error" condition but would only check error constants if there was an error.