### PR TITLE
CertificateCacheV2 and X509CrlCache: Move clear() into the cpp file

### DIFF
--- a/include/ndn-ind/security/v2/certificate-cache-v2.hpp
+++ b/include/ndn-ind/security/v2/certificate-cache-v2.hpp
@@ -98,11 +98,7 @@ public:
    * Clear all certificates from the cache.
    */
   void
-  clear()
-  {
-    certificatesByName_.clear();
-    nextRefreshTime_ = std::chrono::system_clock::time_point::max();
-  }
+  clear();
 
   /**
    * Get the default maximum lifetime (1 hour).

--- a/include/ndn-ind/security/v2/x509-crl-cache.hpp
+++ b/include/ndn-ind/security/v2/x509-crl-cache.hpp
@@ -68,11 +68,7 @@ public:
    * Clear all CRLs from the cache.
    */
   void
-  clear()
-  {
-    crlsByName_.clear();
-    nextRefreshTime_ = std::chrono::system_clock::time_point::max();
-  }
+  clear();
 
   /**
    * X509CrlCache::Entry is the value of the crlsByName_ map.

--- a/src/security/v2/certificate-cache-v2.cpp
+++ b/src/security/v2/certificate-cache-v2.cpp
@@ -126,6 +126,13 @@ CertificateCacheV2::deleteCertificate(const Name& certificateName)
 }
 
 void
+CertificateCacheV2::clear()
+{
+  certificatesByName_.clear();
+  nextRefreshTime_ = system_clock::time_point::max();
+}
+
+void
 CertificateCacheV2::refresh()
 {
   // nowOffset_ is only used for testing.

--- a/src/security/v2/x509-crl-cache.cpp
+++ b/src/security/v2/x509-crl-cache.cpp
@@ -88,6 +88,13 @@ X509CrlCache::find(const Name& issuerName) const
 }
 
 void
+X509CrlCache::clear()
+{
+  crlsByName_.clear();
+  nextRefreshTime_ = system_clock::time_point::max();
+}
+
+void
 X509CrlCache::refresh()
 {
   auto now = system_clock::now();


### PR DESCRIPTION
`CertificateCacheV2` and `X509CrlCache`, the `clear` method is defined inline in the public API. It uses `max()` which could conflict with an application which includes a header file with a different definition of `max()`. This pull request moves the definition of the `clear` method into the cpp file to avoid a conflict in the public API.