### PR TITLE
logging.hpp: Fix typo for non-log4cxx conditions

### DIFF
--- a/include/ndn-ind/util/logging.hpp
+++ b/include/ndn-ind/util/logging.hpp
@@ -92,7 +92,7 @@ INIT_LOGGERS ();
 
 // If the library is not compiled with _DEBUG, it is also possible to define
 // NDN_IND_WITH_LOGGING to send all log messages to clog.
-#if 1 || defined(_DEBUG) || defined(NDN_IND_WITH_LOGGING)
+#if defined(_DEBUG) || defined(NDN_IND_WITH_LOGGING)
 
 #include <time.h>
 #include <iostream>


### PR DESCRIPTION
This pull request fixes a typo in pull request #47 . The conditions for using non-log4cxx logging statements is:

    #if 1 || defined(_DEBUG) || defined(NDN_IND_WITH_LOGGING)

The `1 ||` makes this condition always true. It is a typo left over from testing. This pull request removes it.