### PR TITLE
TcpTransport: Support a ConnectionInfo with an already-open socket

### DIFF
--- a/src/c/transport/socket-transport.h
+++ b/src/c/transport/socket-transport.h
@@ -95,6 +95,29 @@ ndn_Error ndn_SocketTransport_connect
    unsigned short port, struct ndn_ElementListener *elementListener);
 
 /**
+ * Set this transport to use the existing socket descriptor.
+ * @param self A pointer to the ndn_SocketTransport struct.
+ * @param socketDescriptor The socket descriptor, which must already be open.
+ * @param elementListener A pointer to the ndn_ElementListener used by
+ * ndn_SocketTransport_processEvents, which remain valid during the life of this
+ * object or until replaced by the next call to connect.
+ * @return 0 for success, else an error code.
+ */
+static __inline ndn_Error ndn_SocketTransport_useSocket
+  (struct ndn_SocketTransport *self,
+#if defined(_WIN32)
+   SOCKET socketDescriptor,
+#else
+   int socketDescriptor,
+#endif
+   struct ndn_ElementListener *elementListener)
+{
+  ndn_ElementReader_reset(&self->elementReader, elementListener);
+  self->socketDescriptor = socketDescriptor;
+  return NDN_ERROR_success;
+}
+
+/**
  * Send data to the socket.
  * @param self A pointer to the ndn_SocketTransport struct.
  * @param data A pointer to the buffer of data to send.

--- a/src/c/transport/tcp-transport.h
+++ b/src/c/transport/tcp-transport.h
@@ -96,6 +96,27 @@ static __inline ndn_Error ndn_TcpTransport_connect
 }
 
 /**
+ * Set this transport to use the existing socket descriptor.
+ * @param self A pointer to the ndn_TcpTransport struct.
+ * @param socketDescriptor The socket descriptor, which must already be open.
+ * @param elementListener A pointer to the ndn_ElementListener used by
+ * ndn_SocketTransport_processEvents, which remain valid during the life of this
+ * object or until replaced by the next call to connect.
+ * @return 0 for success, else an error code.
+ */
+static __inline ndn_Error ndn_TcpTransport_useSocket
+  (struct ndn_TcpTransport *self,
+#if defined(_WIN32)
+   SOCKET socketDescriptor,
+#else
+   int socketDescriptor,
+#endif
+   struct ndn_ElementListener *elementListener)
+{
+  return ndn_SocketTransport_useSocket(&self->base, socketDescriptor, elementListener);
+}
+
+/**
  * Send data to the socket.
  * @param self A pointer to the ndn_TcpTransport struct.
  * @param data A pointer to the buffer of data to send.

--- a/src/transport/tcp-transport.cpp
+++ b/src/transport/tcp-transport.cpp
@@ -92,10 +92,19 @@ TcpTransport::connect
     dynamic_cast<const TcpTransport::ConnectionInfo&>(connectionInfo);
 
   ndn_Error error;
-  if ((error = ndn_TcpTransport_connect
-       (transport_.get(), (char *)tcpConnectionInfo.getHost().c_str(),
-        tcpConnectionInfo.getPort(), &elementListener)))
-    throw runtime_error(ndn_getErrorString(error));
+  if (tcpConnectionInfo.hasSocketDescriptor()) {
+    // Just use the already-open socket.
+    if ((error = ndn_TcpTransport_useSocket
+         (transport_.get(), tcpConnectionInfo.getSocketDescriptor(),
+          &elementListener)))
+      throw runtime_error(ndn_getErrorString(error));
+  }
+  else {
+    if ((error = ndn_TcpTransport_connect
+         (transport_.get(), (char *)tcpConnectionInfo.getHost().c_str(),
+          tcpConnectionInfo.getPort(), &elementListener)))
+      throw runtime_error(ndn_getErrorString(error));
+  }
 
   isConnected_ = true;
   if (onConnected)


### PR DESCRIPTION
The existing way to create a TCP face is to supply a connection info with a host:

    Face face(
      ptr_lib::make_shared<TcpTransport>(), 
      ptr_lib::make_shared<TcpTransport::ConnectionInfo>("1.2.3.4")));

But the application may have an already-open socket descriptor, for example from a new incoming connection. This pull request adds a `TcpTransport::ConnectionInfo` constructor to supply an already-open socket descriptor:

    int socketDescriptor = myCodeToOpenASocket();
    Face face(
      ptr_lib::make_shared<TcpTransport>(), 
      ptr_lib::make_shared<TcpTransport::ConnectionInfo>(socketDescriptor)));

