### PR TITLE
Only compile cert-install if NDN_IND_HAVE_SQLITE3

### DIFF
--- a/examples/cert-install.cpp
+++ b/examples/cert-install.cpp
@@ -19,6 +19,10 @@
  * A copy of the GNU Lesser General Public License is in the file COPYING.
  */
 
+// Only compile if ndn-ind-config.h defines NDN_IND_HAVE_SQLITE3.
+#include <ndn-ind/ndn-ind-config.h>
+#ifdef NDN_IND_HAVE_SQLITE3
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -68,3 +72,17 @@ int main(int argc, char* argv[])
   
   return 0;
 }
+
+#else // NDN_IND_HAVE_SQLITE3
+
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, char** argv)
+{
+  cout <<
+    "This program uses sqlite3 but it is not installed. Install it and ./configure again." << endl;
+}
+
+#endif // NDN_IND_HAVE_SQLITE3


### PR DESCRIPTION
Most example applications check the config options to make sure the needed dependencies are installed. For example, test-chrono-chat relies on Protobuf, so [it checks for it](https://github.com/operantnetworks/ndn-ind/blob/240a7d4caf785b1656a7df3a51d5451bb93073bc/examples/test-chrono-chat.cpp#L35-L37). The cert-install example program has a dependency on Sqlite3, so this pull request adds a check for it, so that make will succeed if the dependency is not installed.