### PR TITLE
Add X509CertificateInfo::makeX509NameOfCommonName()

### DIFF
--- a/include/ndn-ind/security/certificate/x509-certificate-info.hpp
+++ b/include/ndn-ind/security/certificate/x509-certificate-info.hpp
@@ -181,6 +181,15 @@ public:
   static const Name::Component&
   getX509_COMPONENT();
 
+  /**
+   * Return the X509 name for the specified common name.
+   * 
+   * @param commonName The common name to build the X509 name from.
+   * @return The X509 name as a Blob.
+   */
+  static ndn::Blob
+  makeX509NameOfCommonName(const std::string& commonName);
+
 private:
   ptr_lib::shared_ptr<DerNode> root_;
   SignedBlob signedEncoding_;

--- a/src/security/certificate/x509-certificate-info.cpp
+++ b/src/security/certificate/x509-certificate-info.cpp
@@ -30,6 +30,7 @@ typedef DerNode::DerSequence DerSequence;
 
 static const char *RSA_ENCRYPTION_OID = "1.2.840.113549.1.1.1";
 static const char *PSEUDONYM_OID = "2.5.4.65";
+static const char *COMMON_NAME_OID = "2.5.4.3";
 static const char *SUBJECT_ALTERNATIVE_NAME_OID = "2.5.29.17";
 static const char *CRL_DISTRIBUTION_POINTS_OID = "2.5.29.31";
 static const int GENERAL_NAME_URI_TYPE = 0x86;
@@ -428,5 +429,19 @@ X509CertificateInfo::getX509_COMPONENT()
 }
 
 Name::Component* X509CertificateInfo::X509_COMPONENT = 0;
+
+ndn::Blob
+X509CertificateInfo::makeX509NameOfCommonName(const std::string& commonName)
+{
+  ptr_lib::shared_ptr<DerSequence> root(new DerSequence());
+  ptr_lib::shared_ptr<DerSequence> typeAndValue(new DerSequence());
+  typeAndValue->addChild(ptr_lib::make_shared<DerNode::DerOid>(OID(COMMON_NAME_OID)));
+  typeAndValue->addChild(ptr_lib::make_shared<DerNode::DerUtf8String>
+    ((const uint8_t*)commonName.c_str(), commonName.size()));
+  ptr_lib::shared_ptr<DerNode::DerSet> component(new DerNode::DerSet());
+  component->addChild(typeAndValue);
+  root->addChild(component);
+  return root->encode();
+}
 
 }


### PR DESCRIPTION
This function takes a common name and produces a Blob with the
common name in the X509 name format.